### PR TITLE
Fix use 'Exif.Photo.UserComment' for the ReplaceWithMetadata feature

### DIFF
--- a/administrator/components/com_joomgallery/helpers/upload.php
+++ b/administrator/components/com_joomgallery/helpers/upload.php
@@ -2733,9 +2733,19 @@ class JoomUpload extends JObject
       {
         $attribute = $this->exif_config_array['EXIF'][$configoption]['Attribute'];
 
-        if(isset($metadata_array[0][$attribute]))
+        if($attribute == 'UserComment')
         {
-          $return = $metadata_array[0][$attribute];
+          if(isset($metadata_array[0]['COMPUTED'][$attribute]))
+          {
+            $return = $metadata_array[0]['COMPUTED'][$attribute];
+          }
+        }
+        else
+        {
+          if(isset($metadata_array[0][$attribute]))
+          {
+            $return = $metadata_array[0][$attribute];
+          }
         }
       }
       elseif(array_key_exists($configoption, $this->iptc_config_array['IPTC']))


### PR DESCRIPTION
proper usage of the "Exif.Photo.UserComment" Meta-Tag.
This will fix the issue of the ASCIIA present when using Exif "UserComment".