### PR TITLE
Use of different post variables for the image description in the fron…

### DIFF
--- a/administrator/components/com_joomgallery/helpers/upload.php
+++ b/administrator/components/com_joomgallery/helpers/upload.php
@@ -2330,9 +2330,22 @@ class JoomUpload extends JObject
     $old_info = $this->_mainframe->getUserState('joom.upload.post');
     $cur_info = (!is_null($old_info)) ? $old_info : array();
     $new_info = JRequest::get('post');
-    if(isset($new_info['imgtext']))
+
+    // The use of different post variables for the image description is necessary for the editor form fields to work properly
+    // in the frontend upload view when using multiple upload methods
+    $imgtext = 'imgtext';
+    if($this->_site && ($this->type == 'single' || $this->type == 'batch' || $this->type == 'java'))
     {
-      $new_info['imgtext'] = JComponentHelper::filterText($this->_mainframe->input->post->get('imgtext', '', 'raw'));
+      $imgtexttmp = $this->type . '-' . $imgtext;
+      if(isset($new_info[$imgtexttmp]))
+      {
+        $imgtext = $imgtexttmp;
+      }
+    }
+
+    if(isset($new_info[$imgtext]))
+    {
+      $new_info['imgtext'] = JComponentHelper::filterText($this->_mainframe->input->post->get($imgtext, '', 'raw'));
     }
 
     // Prevent setting access level in frontend

--- a/components/com_joomgallery/models/forms/batchupload.xml
+++ b/components/com_joomgallery/models/forms/batchupload.xml
@@ -43,7 +43,7 @@
         required="true"
       />
       <field
-        name="imgtext"
+        name="batch-imgtext"
         id="batch-imgtext"
         type="editor"
         class="inputbox"

--- a/components/com_joomgallery/models/forms/jupload.xml
+++ b/components/com_joomgallery/models/forms/jupload.xml
@@ -30,7 +30,7 @@
         required="true"
       />
       <field
-        name="imgtext"
+        name="java-imgtext"
         id="java-imgtext"
         type="editor"
         class="inputbox"

--- a/components/com_joomgallery/models/forms/upload.xml
+++ b/components/com_joomgallery/models/forms/upload.xml
@@ -44,7 +44,7 @@
         required="true"
       />
       <field
-        name="imgtext"
+        name="single-imgtext"
         id="single-imgtext"
         type="editor"
         class="inputbox"

--- a/components/com_joomgallery/views/upload/tmpl/default_batch.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_batch.php
@@ -34,10 +34,10 @@
       <?php endif; ?>
   <div class="control-group">
     <div class="control-label">
-      <?php echo $this->batch_form->getLabel('imgtext'); ?>
+      <?php echo $this->batch_form->getLabel('batch-imgtext'); ?>
     </div>
     <div class="controls">
-      <?php echo $this->batch_form->getInput('imgtext'); ?>
+      <?php echo $this->batch_form->getInput('batch-imgtext'); ?>
     </div>
   </div>
   <div class="control-group">

--- a/components/com_joomgallery/views/upload/tmpl/default_java.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_java.php
@@ -24,10 +24,10 @@
       <?php endif; ?>
   <div class="control-group">
     <div class="control-label">
-      <?php echo $this->applet_form->getLabel('imgtext'); ?>
+      <?php echo $this->applet_form->getLabel('java-imgtext'); ?>
     </div>
     <div class="controls">
-      <?php echo $this->applet_form->getInput('imgtext'); ?>
+      <?php echo $this->applet_form->getInput('java-imgtext'); ?>
     </div>
   </div>
   <div class="control-group">

--- a/components/com_joomgallery/views/upload/tmpl/default_single.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_single.php
@@ -30,10 +30,10 @@
       <?php endif; ?>
   <div class="control-group">
     <div class="control-label">
-      <?php echo $this->single_form->getLabel('imgtext'); ?>
+      <?php echo $this->single_form->getLabel('single-imgtext'); ?>
     </div>
     <div class="controls">
-      <?php echo $this->single_form->getInput('imgtext'); ?>
+      <?php echo $this->single_form->getInput('single-imgtext'); ?>
     </div>
   </div>
   <div class="control-group">


### PR DESCRIPTION
…tend upload view.

The use of different post variables for the image description is necessary for the editor form fields to work properly in the frontend upload view when using multiple upload methods.

See also #33 for more information.