### PR TITLE
Add HTML attribute lazy loading to thumbnails in frontend

### DIFF
--- a/components/com_joomgallery/views/category/tmpl/default_images.php
+++ b/components/com_joomgallery/views/category/tmpl/default_images.php
@@ -32,7 +32,7 @@
     <div class="jg_element_cat">
       <div class="jg_imgalign_catimgs">
         <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>" class="jg_catelem_photo jg_catelem_photo_align">
-          <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" <?php echo $row->imgwh; ?> alt="<?php echo $row->imgtitle; ?>" /></a>
+          <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" <?php echo $row->imgwh; ?> alt="<?php echo $row->imgtitle; ?>" loading="lazy" /></a>
       </div>
 <?php if($row->show_elems): ?>
       <div class="jg_catelem_txt">

--- a/components/com_joomgallery/views/category/tmpl/default_subcategories.php
+++ b/components/com_joomgallery/views/category/tmpl/default_subcategories.php
@@ -54,7 +54,7 @@
         <div class="jg_imgalign_catsubs">
           <div class="<?php echo $row->photocontainer; ?>">
             <a title="<?php echo $row->name; ?>" href="<?php echo $row->link; ?>">
-              <img src="<?php echo $row->thumb_src; ?>" hspace="4" vspace="0" class="jg_photo" alt="<?php echo $row->name; ?>" />
+              <img src="<?php echo $row->thumb_src; ?>" hspace="4" vspace="0" class="jg_photo" alt="<?php echo $row->name; ?>" loading="lazy" />
             </a>
 <?php       endif;
           endif;

--- a/components/com_joomgallery/views/detail/tmpl/default.php
+++ b/components/com_joomgallery/views/detail/tmpl/default.php
@@ -218,7 +218,7 @@ echo $this->loadTemplate('header'); ?>
           if($row->id == $this->image->id):
             $cssid = ' id="jg_mini_akt"';
           endif; ?>
-            <img src="<?php echo $this->_ambit->getImg('thumb_url', $row); ?>"<?php echo $cssid; ?> class="jg_minipic" alt="<?php echo $row->imgtitle; ?>" /></a>
+            <img src="<?php echo $this->_ambit->getImg('thumb_url', $row); ?>"<?php echo $cssid; ?> class="jg_minipic" alt="<?php echo $row->imgtitle; ?>" loading="lazy" /></a>
 <?php     if($this->_config->get('jg_motionminis') == 2): ?>
         </li>
 <?php     endif; ?>

--- a/components/com_joomgallery/views/favourites/tmpl/default.php
+++ b/components/com_joomgallery/views/favourites/tmpl/default.php
@@ -33,7 +33,7 @@ echo $this->loadTemplate('header');?>
         <div class="jg_imgalign_fav">
           <div class="jg_favelem_photo">
             <a href="<?php echo $row->link; ?>" <?php echo $row->atagtitle; ?>>
-              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" />
+              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" loading="lazy" />
             </a>
           </div>
         </div>

--- a/components/com_joomgallery/views/gallery/tmpl/default.php
+++ b/components/com_joomgallery/views/gallery/tmpl/default.php
@@ -35,7 +35,7 @@ echo $this->loadTemplate('header'); ?>
       <div class="jg_imgalign_gal">
         <div class="<?php echo $row->photocontainer; ?>">
           <a title="<?php echo $row->name; ?>" href="<?php echo $row->link ?>">
-            <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->name; ?>" />
+            <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->name; ?>" loading="lazy" />
           </a>
         </div>
       </div>

--- a/components/com_joomgallery/views/search/tmpl/default.php
+++ b/components/com_joomgallery/views/search/tmpl/default.php
@@ -24,7 +24,7 @@ echo $this->loadTemplate('header'); ?>
         <div class="jg_imgalign_search">
           <div  class="jg_searchelem_photo">
             <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>">
-              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" />
+              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" loading="lazy" />
             </a>
           </div>
         </div>

--- a/components/com_joomgallery/views/toplist/tmpl/default.php
+++ b/components/com_joomgallery/views/toplist/tmpl/default.php
@@ -26,7 +26,7 @@ echo $this->loadTemplate('header'); ?>
 <?php     endif; ?>
           <div class="jg_topelem_photo">
             <a <?php echo $row->atagtitle; ?> href="<?php echo $row->link; ?>">
-              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" />
+              <img src="<?php echo $row->thumb_src; ?>" class="jg_photo" alt="<?php echo $row->imgtitle; ?>" loading="lazy" />
             </a>
           </div>
 <?php     if($this->_config->get('jg_imgalign') && $this->_config->get('jg_toplistcols') > 1): ?>


### PR DESCRIPTION
Most browsers now support the HTML attribute loading="lazy" natively.
Further informations: https://www.ghsvs.de/programmierer-schnipsel/sonstige/288-natives-lazy-loading-fuer-bilder-ohne-extra-javascript
and https://forum.joomla.de/thread/11645-problem-mit-nativem-loading-lazy/
Integration is also planned for Joomla, see: https://github.com/joomla/joomla-cms/pull/28929 and https://github.com/joomla/joomla-cms/pull/28838

In places where many images are loaded, such as the category view, motion gallery or the top lists it should be positive for the User Experience.
I didn't use a new configuration option because there are probably no negative effects to be afraid?

Possibly we should add this attribute in other places, e.g. in the function joomgallery.minithumbimg and in backend?