### PR TITLE
Favourites conflict with K2 system plugin

### DIFF
--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -90,7 +90,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
 
     // Set the image id
     $view = JRequest::getCmd('view');
-    $task = JRequest::getCmd('task');
+    $task = JFactory::getApplication()->input->get('task');
     if(  ($view != 'favourites' || $task == 'removeimage')
       &&  $view != 'downloadzip'
       &&  $task != 'removeall'


### PR DESCRIPTION
If the plugin 'System - K2' from K2 component (v2.10.3) is activated, the favorites function does not work. No zip file is created.
This change should resolve the conflict.
See also: https://www.forum.joomgalleryfriends.net/forum/index.php?thread/105-my-favourites-not-working/