### PR TITLE
Fix SQL error in some batch jobs in Maintenance Manager

### DIFF
--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -465,6 +465,13 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    if(!count($cids))
+    {
+      $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
+
+      return false;
+    }
+
     JArrayHelper::toInteger($cids);
 
     $query = $this->_db->getQuery(true);
@@ -486,13 +493,6 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     }
 
     $row = $this->getTable('joomgalleryimages');
-
-    if(!count($cids))
-    {
-      $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
-
-      return false;
-    }
 
     $count = 0;
 
@@ -637,6 +637,13 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    if(!count($cids))
+    {
+      $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
+
+      return false;
+    }
+
     JArrayHelper::toInteger($cids);
 
     if(!$recursion_level)
@@ -663,13 +670,6 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     }
 
     $row = $this->getTable('joomgallerycategories');
-
-    if(!count($cids))
-    {
-      $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
-
-      return false;
-    }
 
     $count = 0;
     $extant_images  = false;


### PR DESCRIPTION
When using some batch jobs without selectet images a SQL error occurs

### Testing Instructions

Go to Maintenance Manager - Tab Images
Select Batch Jobs: Delete images
Use Apply

### Expected result

Warning that no images have been selected

### Actual result

1064 You have an error in your SQL syntax...


The same is in the Categories tab