### PR TITLE
Plugin events (new and modified)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -554,3 +554,4 @@
 /joomla.xml
 /*.txt
 /robots.txt.dist
+/nbproject/*

--- a/administrator/components/com_joomgallery/helpers/upload.php
+++ b/administrator/components/com_joomgallery/helpers/upload.php
@@ -374,7 +374,7 @@ class JoomUpload extends JObject
       }
 
       // Trigger onJoomBeforeUpload
-      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload');
+      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($images['name'][$i]));
       if(in_array(false, $plugins, true))
       {
         continue;
@@ -729,20 +729,20 @@ class JoomUpload extends JObject
         break;
       }
 
-      // Trigger event 'onJoomBeforeUpload'
-      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload');
-      if(in_array(false, $plugins, true))
-      {
-        unset($ziplist[$key]);
-        continue;
-      }
-
       // Get the filename without path, JFile::getName() does not
       // work on local installations
       $filepathinfos  = pathinfo($file);
       $origfilename   = $filepathinfos['basename'];
       $filesize       = filesize($file);
       $tag            = strtolower(JFile::getExt($origfilename));
+
+      // Trigger event 'onJoomBeforeUpload'
+      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($origfilename));
+      if(in_array(false, $plugins, true))
+      {
+        unset($ziplist[$key]);
+        continue;
+      }      
 
       $this->_debugoutput .= '<hr />';
       $this->_debugoutput .= JText::sprintf('COM_JOOMGALLERY_UPLOAD_FILENAME', $origfilename).'<br />';
@@ -1033,7 +1033,7 @@ class JoomUpload extends JObject
       }
 
       // Trigger event 'onJoomBeforeUpload'
-      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload');
+      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($fileArray['name']));
       if(in_array(false, $plugins, true))
       {
         $this->_debugoutput .= 'Upload was stopped by a plugin';
@@ -1355,6 +1355,14 @@ class JoomUpload extends JObject
         $refresher->refresh(count($ftpfiles));
       }
 
+      // Trigger onJoomBeforeUpload
+      $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($origfilename));
+      if(in_array(false, $plugins, true))
+      {
+        unset($ftpfiles[$key]);
+        continue;
+      }
+
       // Get extension
       $tag = strtolower(JFile::getExt($origfilename));
 
@@ -1627,7 +1635,7 @@ class JoomUpload extends JObject
     }
 
     // Trigger onJoomBeforeUpload
-    $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload');
+    $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($image['name']));
     if(in_array(false, $plugins, true))
     {
       $errorMsg = JText::_('COM_JOOMGALLERY_AJAXUPLOAD_UPLOAD_FAILED');

--- a/administrator/components/com_joomgallery/helpers/upload.php
+++ b/administrator/components/com_joomgallery/helpers/upload.php
@@ -1635,7 +1635,7 @@ class JoomUpload extends JObject
     }
 
     // Trigger onJoomBeforeUpload
-    $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($image['name']));
+    $plugins  = $this->_mainframe->triggerEvent('onJoomBeforeUpload', array($origfilename));
     if(in_array(false, $plugins, true))
     {
       $errorMsg = JText::_('COM_JOOMGALLERY_AJAXUPLOAD_UPLOAD_FAILED');

--- a/administrator/components/com_joomgallery/models/categories.php
+++ b/administrator/components/com_joomgallery/models/categories.php
@@ -721,6 +721,8 @@ class JoomGalleryModelCategories extends JoomGalleryModel
       }
     }
 
+    $this->_mainframe->triggerEvent('onCategoryChangeState', array(_JOOM_OPTION, $cid, $publish));
+
     return $count;
   }
 

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -1172,6 +1172,8 @@ class JoomGalleryModelImage extends JoomGalleryModel
       return false;
     }
 
+    $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image', &$item, false));
+
     return true;
   }
 

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -363,6 +363,9 @@ class JoomGalleryModelImage extends JoomGalleryModel
         return false;
       }
 
+      // Trigger the before save event.
+		  $this->_mainframe->triggerEvent('onContentBeforeSave', array(_JOOM_OPTION.'.image', &$row, true, $data));
+
       // Copy the image files, the row will be stored, too
       if(!$this->_newImage($row, $catpath, $detail_catpath, $thumb_catpath, $data['copy_original']))
       {
@@ -374,6 +377,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
       // Successfully stored new image
       $row->reorder('catid = '.$row->catid);
 
+      // Trigger the after save event.
       $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image', &$row, true));
 
       return $row->id;
@@ -710,6 +714,9 @@ class JoomGalleryModelImage extends JoomGalleryModel
       }
     }
 
+    // Trigger the before save event.
+		$this->_mainframe->triggerEvent('onContentBeforeSave', array(_JOOM_OPTION.'.image'.(!$validate ? '.batch' : ''), &$row, false, $data));
+
     // Move the image if necessary (the data is stored in function moveImage because
     // we have ensured that the old and new category ID are different from each other)
     if($move && !$this->moveImage($row, $row->catid, $catid_old))
@@ -744,6 +751,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
       $row->reorder('catid = '.$catid_old);
     }
 
+    // Trigger the after save event.
     $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image'.(!$validate ? '.batch' : ''), &$row, false));
 
     return $row->id;
@@ -1164,6 +1172,9 @@ class JoomGalleryModelImage extends JoomGalleryModel
       return false;
     }
 
+    // Trigger the before save event.
+		$this->_mainframe->triggerEvent('onContentBeforeSave', array(_JOOM_OPTION.'.image', &$item, false));
+
     // Store the entry to the database
     if(!$item->store())
     {
@@ -1172,6 +1183,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
       return false;
     }
 
+    // Trigger the after save event.
     $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image', &$item, false));
 
     return true;

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -583,7 +583,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
         continue;
       }
 
-      $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $id, array('published'=>$row->published,'approved'=>$row->approved,'featured'=>$row->featured)));
+      $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $row, array('published'=>$row->published,'approved'=>$row->approved,'featured'=>$row->featured)));
 
       // If publishing or unpublishung wasn't successful, decrease the
       // counter of successfully published or unpublished images

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -806,6 +806,10 @@ class JoomGalleryModelImages extends JoomGalleryModel
         $img_count++;
       }
 
+      // trigger Event "onJoomAfterRecreate". Attached is an array with infos about the recreation
+      // files: path to the files; orig_exists: true, if original exists; auto_rotation: is there auto rotation for the different image
+      $this->_mainframe->triggerEvent('onJoomAfterRecreate', array( 'files'=> array('original'=>$orig,'detail'=>$img,'thumbnail'=>$thumb),'orig_exists'=>$orig_existent,'auto_rotation'=> array('original'=>$autorot_orig,'detail'=>$autorot_det,'thumbnail'=>$autorot_thumb) ));
+
       unset($cids[$key]);
 
       // Check remaining time
@@ -1007,6 +1011,10 @@ class JoomGalleryModelImages extends JoomGalleryModel
           $err          = true;
         }
       }
+
+      // trigger Event "onJoomAfterRotate". Attached is an array with infos about the rotation
+      // files: path to the files; rotation_angle: the angle by which the images were rotated; rotateImageTypes: 1(Thumbs and details), 2(All images)
+      $this->_mainframe->triggerEvent('onJoomAfterRotate', array( 'files'=> array('original'=>$orig,'detail'=>$img,'thumbnail'=>$thumb),'rotation_angle'=> $rotateImageAngle,'rotateimagetypes'=>$rotateimagetypes));
 
       unset($cids[$key]);
 

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -591,7 +591,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
       }
     }
 
-    $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $cid, array($task=>$publish)));
+    $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $cid, $publish, $task));
 
     return $count;
   }

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -591,7 +591,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
       }
     }
 
-    $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $cid, $publish, $task));
+    $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $cid, array('publish'=>$publish,'task'=>$task)));
 
     return $count;
   }

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -583,15 +583,15 @@ class JoomGalleryModelImages extends JoomGalleryModel
         continue;
       }
 
-      $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $row, array('published'=>$row->published,'approved'=>$row->approved,'featured'=>$row->featured)));
-
       // If publishing or unpublishung wasn't successful, decrease the
       // counter of successfully published or unpublished images
       if($row->$column != $publish)
       {
         $count--;
       }
-    }    
+    }
+
+    $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $cid, array($task=>$publish)));
 
     return $count;
   }

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -583,13 +583,15 @@ class JoomGalleryModelImages extends JoomGalleryModel
         continue;
       }
 
+      $this->_mainframe->triggerEvent('onContentChangeState', array(_JOOM_OPTION.'.image', $id, array('published'=>$row->published,'approved'=>$row->approved,'featured'=>$row->featured)));
+
       // If publishing or unpublishung wasn't successful, decrease the
       // counter of successfully published or unpublished images
       if($row->$column != $publish)
       {
         $count--;
       }
-    }
+    }    
 
     return $count;
   }

--- a/components/com_joomgallery/models/edit.php
+++ b/components/com_joomgallery/models/edit.php
@@ -159,7 +159,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
       // Unset the data of fields which we aren't allowed to change
       $form->setFieldAttribute('published', 'filter', 'unset');
     }
-    
+
     if(!$this->_config->get('jg_edit_metadata'))
     {
       $form->setFieldAttribute('metakey', 'disabled', 'true');
@@ -373,6 +373,9 @@ class JoomGalleryModelEdit extends JoomGalleryModel
       }
     }
 
+    // Trigger the before save event.
+    $this->_mainframe->triggerEvent('onContentBeforeSave', array(_JOOM_OPTION.'.image', &$row, false, $data));
+
     if($move && !$this->moveImage($row, $row->catid, $catid_old))
     {
       $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_IMAGE'), 'notice');
@@ -405,6 +408,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
       $row->reorder('catid = '.$catid_old);
     }
 
+    // Trigger the after save event.
     $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image', &$row, false));
 
     return $row->id;
@@ -459,13 +463,16 @@ class JoomGalleryModelEdit extends JoomGalleryModel
       throw new RuntimeException($row->getError());
     }
 
+    // Trigger the before save event.
+    $this->_mainframe->triggerEvent('onContentBeforeSave', array(_JOOM_OPTION.'.image.quick', &$row, false, $data));
+
     // Store the entry to the database
     if(!$row->store())
     {
       throw new RuntimeException($row->getError());
     }
 
-    // Successfully stored image
+    // Trigger the after save event.
     $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.image.quick', &$row, false));
 
     return true;

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -901,6 +901,11 @@ class JoomGalleryViewCategory extends JoomGalleryView
       $this->assignRef('order_dir', $orderdir);
     }
 
+    // Get additional view data
+    // Important Note: Please push the additional data into $image->additionalData['pluginName']
+    $cat->additionalData = array();
+    $this->_mainframe->triggerEvent('onJoomAfterPrepareDisplayHTML', array('category', &$cat));
+
     // Set redirect url used in editor links to redirect back to favourites view after edit/delete
     $redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
 

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -1107,6 +1107,11 @@ class JoomGalleryViewDetail extends JoomGalleryView
       }
     }
 
+    // Get additional view data
+    // Important Note: Please push the additional data into $image->additionalData['pluginName']
+    $image->additionalData = array();
+    $this->_mainframe->triggerEvent('onJoomAfterPrepareDisplayHTML', array('detail', &$image));
+
     $icons        = $this->_mainframe->triggerEvent('onJoomDisplayIcons', array('detail.image', $image));
     $event->icons = implode('', $icons);
     $afterDisplay = $this->_mainframe->triggerEvent('onJoomAfterDisplayDetailImage', array($image));


### PR DESCRIPTION
During my work with the JoomGallery I missed some Plugin events.
Especially for actions performed in the images list view (change state, recreate, rotate) I would like to have additional event triggers. During the upload process I miss some information in the onJoomBeforeUpload, in order to know which image will be uploaded after the event.