### PR TITLE
Add missing language constants

### DIFF
--- a/administrator/language/en-GB/en-GB.com_joomgallery.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.sys.ini
@@ -57,3 +57,12 @@ COM_JOOMGALLERY_LAYOUT_USERCATEGORIES_DEFAULT="User Categories: Default Layout"
 COM_JOOMGALLERY_LAYOUT_USERCATEGORIES_DEFAULT_DESC="The default layout for the user categories."
 COM_JOOMGALLERY_LAYOUT_USERPANEL_DEFAULT="User Panel: Default Layout"
 COM_JOOMGALLERY_LAYOUT_USERPANEL_DEFAULT_DESC="The default layout of the user panel."
+;-------
+; Advanced Permissions Report, new since JoomGallery 3.5.1
+COM_JOOMGALLERY_ACTION_UPLOAD="Upload"
+COM_JOOMGALLERY_ACTION_UPLOAD_INOWN="Upload in Own"
+COM_JOOMGALLERY_ACTION_CREATE_INOWN="Create in Own"
+COM_JOOMGALLERY_ACTION_COMPONENT_UPLOAD_DESC="Allow users in the group to upload images into any categories."
+COM_JOOMGALLERY_ACTION_COMPONENT_UPLOAD_INOWN_DESC="Allow users in the group to upload images into their own categories."
+COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_DESC="Allow users in the group to create categories in this extension."
+COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_INOWN_DESC="Allow users in the group to create categories in their own categories."


### PR DESCRIPTION
This PR adds some language constants in en-GB.com_joomgallery.sys.ini.
The language constants are required in the Joomla users 'Advanced Permissions Report'.