### PR TITLE
Add anchor to image link in the category view

### DIFF
--- a/administrator/components/com_joomgallery/helpers/html/joomgallery.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomgallery.php
@@ -573,7 +573,7 @@ abstract class JHtmlJoomGallery
     switch($open)
     {
       case '0': // Detail view
-        $link = JRoute::_('index.php?view=detail&id='.$image->id);
+        $link = JRoute::_('index.php?view=detail&id='.$image->id.JHTML::_('joomgallery.anchor'));
         break;
       case 1: // New window
         $link = $img_url."\" target=\"_blank";

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -775,7 +775,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
         $images[$key]->isnew = JoomHelper::checkNew($image->imgdate, $this->_config->get('jg_daysnew'));
       }
 
-      $images[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $image);
+      $images[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $image).JHTML::_('joomgallery.anchor');
 
       if($this->_config->get('jg_showauthor'))
       {

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -775,7 +775,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
         $images[$key]->isnew = JoomHelper::checkNew($image->imgdate, $this->_config->get('jg_daysnew'));
       }
 
-      $images[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $image).JHTML::_('joomgallery.anchor');
+      $images[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $image);
 
       if($this->_config->get('jg_showauthor'))
       {


### PR DESCRIPTION
Adds the anchor in the link to the detail view in the category view.
I'm not sure if this pull request should be directed to the master or 3.6.0 branch?
Since there is a configuration setting for it, it could be seen as a bug because the setting was ignored. 