### PR TITLE
Fix deletion of non-empty categories in the backend

### DIFF
--- a/administrator/components/com_joomgallery/models/categories.php
+++ b/administrator/components/com_joomgallery/models/categories.php
@@ -630,8 +630,11 @@ class JoomGalleryModelCategories extends JoomGalleryModel
         }
       }
       $msg .= '<br /><br />'.JText::_('COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_NOTE').'<p/>
-      <form action="index.php?option='._JOOM_OPTION.'&amp;controller=categories&amp;task=deletecompletely" method="post" onsubmit="if(!this.security_check.checked){return false;}">
-        <span><input type="checkbox" name="security_check" value="1" /> <button class="btn">'.JText::_('COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL').'</button></span>
+      <form method="post">
+        <span><button class="btn">'.JText::_('COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL').'</button></span>
+        <input type="hidden" name="option" value="'._JOOM_OPTION.'" />
+        <input type="hidden" name="controller" value="categories" />
+        <input type="hidden" name="task" value="deletecompletely" />
       </form><p/>';
       $this->_mainframe->enqueueMessage($msg, 'notice');
     }

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -133,8 +133,6 @@ COM_JOOMGALLERY_CATMAN_MSG_CATEGORY_PUBLISHED="Category was published."
 COM_JOOMGALLERY_CATMAN_MSG_CATEGORY_REJECTED="Category was rejected."
 COM_JOOMGALLERY_CATMAN_MSG_CATEGORY_SAVED="Category saved"
 COM_JOOMGALLERY_CATMAN_MSG_CATEGORY_UNPUBLISHED="Category was unpublished."
-COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY="If you want to delete all selected categories which still contain images or sub-categories please check the box below and push the button."
-COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL="Delete"
 COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_CATEGORIES_NUMBER="<strong><i>Please note</i></strong> that %1$d categories will be deleted altogether."
 COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_CATEGORIES_NUMBER_1="<strong><i>Please note</i></strong> that one category will be deleted."
 COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_IMAGES_NUMBER="<strong><i>Please note</i></strong> that %1$d images will be deleted altogether."
@@ -1713,3 +1711,8 @@ COM_JOOMGALLERY_COMMON_ROTATE_OPTIONS_THUMBS_DETAILS_DESC="The Details of the se
 ;New
 ;-------
 COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_TO_EDIT_IMAGE="You are not allowed to edit this image"
+;-------
+;Changed
+;-------
+COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY="If you want to delete all selected categories which still contain images or sub-categories please push the button below."
+COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL="Delete completely"


### PR DESCRIPTION
The deletion of non-empty categories in the backend is not possible anymore since Joomla applies a Html input filter on alert messages introduced as security fix in Joomla 3.9.25.

This pull request should fix that.

Additionally I have removed the checkbox in front of the "Delete completely" button, because firstly I think it is not neccessary to have another security question inside the message that is a security question itself and secondly the neccessary script would be filtered by Joomla either.