### PR TITLE
Change needed access rule for maintenance view

### DIFF
--- a/administrator/components/com_joomgallery/controllers/maintenance.php
+++ b/administrator/components/com_joomgallery/controllers/maintenance.php
@@ -30,9 +30,9 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
     parent::__construct();
 
     // Access check
-    if(!JFactory::getUser()->authorise('core.admin', _JOOM_OPTION))
+    if(!JFactory::getUser()->authorise('core.manage', _JOOM_OPTION))
     {
-      $this->setRedirect(JRoute::_($this->_ambit->getRedirectUrl(''), false), 'You are not allowed to configure this component', 'notice');
+      $this->setRedirect(JRoute::_($this->_ambit->getRedirectUrl(''), false), 'You are not allowed to manage this component', 'notice');
       $this->redirect();
     }
 

--- a/administrator/components/com_joomgallery/helpers/helper.php
+++ b/administrator/components/com_joomgallery/helpers/helper.php
@@ -61,6 +61,10 @@ class JoomHelper
     {
       unset($controllers['config']);
       unset($controllers['cssedit']);
+    }
+
+    if(!$canDo->get('core.manage'))
+    {
       unset($controllers['maintenance']);
     }
 

--- a/administrator/components/com_joomgallery/models/control.php
+++ b/administrator/components/com_joomgallery/models/control.php
@@ -59,6 +59,9 @@ class JoomGalleryModelControl extends JoomGalleryModel
     {
       $where[] = "link LIKE 'index.php?option=com_joomgallery&controller=config%'";
       $where[] = "link LIKE 'index.php?option=com_joomgallery&controller=cssedit%'";
+    }
+    if($canDo->get('core.manage'))
+    {
       $where[] = "link LIKE 'index.php?option=com_joomgallery&controller=maintenance%'";
     }
 


### PR DESCRIPTION
This pull request changes the  necessary access permission rule in order to open and use the maintenance view from core.admin to core.manage.

The maintenance manager is a tool for monitoring and optimising JoomGallery content like images, categories, comments, votes, etc. It is therefore smart to give a manager access to this view since it is the job of a websites manager to manage, monitor and check content that is created on the website.
In my opinion there is no need to be a system administrator in order to access the maintanace manager. 