### PR TITLE
Add 'delete own' permission

### DIFF
--- a/administrator/components/com_joomgallery/access.xml
+++ b/administrator/components/com_joomgallery/access.xml
@@ -8,6 +8,7 @@
 		<action name="core.create" title="JACTION_CREATE" description="COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_DESC" />
 		<action name="joom.create.inown" title="COM_JOOMGALLERY_ACTION_CREATE_INOWN" description="COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_INOWN_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="JACTION_DELETE_COMPONENT_DESC" />
+		<action name="joom.delete.own" title="COM_JOOMGALLERY_ACTION_DELETE_OWN" description="COM_JOOMGALLERY_ACTION_COMPONENT_DELETE_OWN_DESC" />
 		<action name="core.edit" title="JACTION_EDIT" description="JACTION_EDIT_COMPONENT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="JACTION_EDITSTATE_COMPONENT_DESC" />
 		<action name="core.edit.own" title="JACTION_EDITOWN" description="JACTION_EDITOWN_COMPONENT_DESC" />
@@ -18,12 +19,14 @@
 		<action name="core.create" title="JACTION_CREATE" description="COM_JOOMGALLERY_ACTION_CATEGORY_CREATE_DESC" />
 		<action name="joom.create.inown" title="COM_JOOMGALLERY_ACTION_CREATE_INOWN" description="COM_JOOMGALLERY_ACTION_CATEGORY_CREATE_INOWN_DESC" />
 		<action name="core.delete" title="JACTION_DELETE" description="COM_JOOMGALLERY_ACTION_CATEGORY_DELETE_DESC" />
+		<action name="joom.delete.own" title="COM_JOOMGALLERY_ACTION_DELETE_OWN" description="COM_JOOMGALLERY_ACTION_CATEGORY_DELETE_OWN_DESC" />
 		<action name="core.edit" title="JACTION_EDIT" description="COM_JOOMGALLERY_ACTION_CATEGORY_EDIT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="COM_JOOMGALLERY_ACTION_CATEGORY_EDITSTATE_DESC" />
 		<action name="core.edit.own" title="JACTION_EDITOWN" description="COM_JOOMGALLERY_ACTION_CATEGORY_EDITOWN_DESC" />
 	</section>
 	<section name="image">
 		<action name="core.delete" title="JACTION_DELETE" description="COM_JOOMGALLERY_ACTION_IMAGE_DELETE_DESC" />
+		<action name="joom.delete.own" title="COM_JOOMGALLERY_ACTION_DELETE_OWN" description="COM_JOOMGALLERY_ACTION_IMAGE_DELETE_OWN_DESC" />
 		<action name="core.edit" title="JACTION_EDIT" description="COM_JOOMGALLERY_ACTION_IMAGE_EDIT_DESC" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" description="COM_JOOMGALLERY_ACTION_IMAGE_EDITSTATE_DESC" />
 		<action name="core.edit.own" title="JACTION_EDITOWN" description="COM_JOOMGALLERY_ACTION_IMAGE_EDITOWN_DESC" />

--- a/administrator/components/com_joomgallery/controllers/images.php
+++ b/administrator/components/com_joomgallery/controllers/images.php
@@ -232,13 +232,17 @@ class JoomGalleryControllerImages extends JoomGalleryController
   public function remove()
   {
     $model = $this->getModel('images');
-
-    $cid  = JRequest::getVar('cid', array(), 'post', 'array');
+    $user  = JFactory::getUser();
+    $row   = JTable::getInstance('joomgalleryimages', 'Table');
+    $cid   = JRequest::getVar('cid', array(), 'post', 'array');
     $unaffected_images = 0;
     foreach($cid as $key => $id)
     {
+      $row->load((int)$id);
+
       // Prune images which we aren't allowed to delete
-      if(!JFactory::getUser()->authorise('core.delete', _JOOM_OPTION.'.image.'.$id))
+      if(   !$user->authorise('core.delete', _JOOM_OPTION.'.image.'.$id)
+        && (!$user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$id) || !$row->owner || $row->owner != $user->get('id')))
       {
         unset($cid[$key]);
         $unaffected_images++;

--- a/administrator/components/com_joomgallery/helpers/helper.php
+++ b/administrator/components/com_joomgallery/helpers/helper.php
@@ -149,6 +149,10 @@ class JoomHelper
       {
         $action2 = 'core.edit.own';
       }
+      if($action == 'core.delete')
+      {
+        $action2 = 'joom.delete.own';
+      }
 
       if(     $user->authorise($action, _JOOM_OPTION.'.category.'.$category->cid)
           ||  (     $action2

--- a/administrator/components/com_joomgallery/helpers/helper.php
+++ b/administrator/components/com_joomgallery/helpers/helper.php
@@ -96,7 +96,7 @@ class JoomHelper
     $user   = JFactory::getUser();
     $result = new JObject();
 
-    $actions = array('core.admin', 'core.manage', 'joom.upload', 'joom.upload.inown', 'core.create', 'joom.create.inown', 'core.edit', 'core.edit.own', 'core.edit.state', 'core.delete');
+    $actions = array('core.admin', 'core.manage', 'joom.upload', 'joom.upload.inown', 'core.create', 'joom.create.inown', 'core.edit', 'core.edit.own', 'core.edit.state', 'core.delete', 'joom.delete.own');
 
     switch($type)
     {

--- a/administrator/components/com_joomgallery/models/categories.php
+++ b/administrator/components/com_joomgallery/models/categories.php
@@ -526,8 +526,11 @@ class JoomGalleryModelCategories extends JoomGalleryModel
     // Loop through selected categories
     foreach($ids as $cid)
     {
+      $row->load($cid);
+
       // Check whether we are allowed to delete this category
-      if(!$this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$cid))
+      if(   !$this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$cid)
+        && (!$this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.category.'.$cid) || !$row->owner || $row->owner != $this->_user->get('id')))
       {
         JLog::add(JText::sprintf('COM_JOOMGALLERY_CATMAN_ERROR_DELETE_NOT_PERMITTED', $cid), JLog::ERROR, 'jerror');
 
@@ -585,7 +588,6 @@ class JoomGalleryModelCategories extends JoomGalleryModel
           JLog::add(JText::_('COM_JOOMGALLERY_CATMAN_MSG_ERROR_DELETING_DIRECTORIES'), JLog::WARNING, 'jerror');
         }
 
-        $row->load($cid);
         if(!$row->delete())
         {
           throw new RuntimeException($row->getError());

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -414,14 +414,15 @@ class JoomGalleryModelImages extends JoomGalleryModel
     // Loop through selected images
     foreach($ids as $cid)
     {
-      if(!$this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$cid))
+      $row->load($cid);
+
+      if(   !$this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$cid)
+        && (!$this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$cid) || !$row->owner || $row->owner != $this->_user->get('id')))
       {
         JLog::add(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_DELETE_NOT_PERMITTED', 1), JLog::ERROR, 'jerror');
 
         continue;
       }
-
-      $row->load($cid);
 
       // Database query to check if there are other images which this
       // thumbnail is assigned to and how many of them exist

--- a/administrator/components/com_joomgallery/views/categories/view.html.php
+++ b/administrator/components/com_joomgallery/views/categories/view.html.php
@@ -82,7 +82,7 @@ class JoomGalleryViewCategories extends JoomGalleryView
       JToolbarHelper::divider();
     }
 
-    if(($this->_config->get('jg_disableunrequiredchecks') || $canDo->get('core.delete') || count(JoomHelper::getAuthorisedCategories('core.delete'))) && $this->pagination->total)
+    if(($this->_config->get('jg_disableunrequiredchecks') || $canDo->get('core.delete') || $canDo->get('joom.delete.own') || count(JoomHelper::getAuthorisedCategories('core.delete'))) && $this->pagination->total)
     {
       JToolbarHelper::deleteList('','remove');
       JToolbarHelper::divider();

--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -61,7 +61,7 @@ class JoomGalleryViewImages extends JoomGalleryView
 
     JToolBarHelper::title(JText::_('COM_JOOMGALLERY_IMGMAN_IMAGE_MANAGER'), 'images');
 
-    if(($this->_config->get('jg_disableunrequiredchecks') || $canDo->get('joom.upload') || count(JoomHelper::getAuthorisedCategories('joom.upload'))) && $this->pagination->total)
+    if($this->_config->get('jg_disableunrequiredchecks') || $canDo->get('joom.upload') || count(JoomHelper::getAuthorisedCategories('joom.upload')))
     {
       JToolbarHelper::addNew('new');
     }

--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -89,10 +89,11 @@ class JoomGalleryViewImages extends JoomGalleryView
       JToolbarHelper::divider();
     }
 
-    if($canDo->get('core.delete') || $canDo->get('joom.delete.own'))
-    {
+    //if($canDo->get('core.delete') || $canDo->get('joom.delete.own'))
+    //{
       JToolbarHelper::deleteList('', 'remove');
-    }
+    //}
+
   }
 
   /**

--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -89,11 +89,10 @@ class JoomGalleryViewImages extends JoomGalleryView
       JToolbarHelper::divider();
     }
 
-    //if($canDo->get('core.delete') || $canDo->get('joom.delete.own'))
-    //{
+    if($this->pagination->total)
+    {
       JToolbarHelper::deleteList('', 'remove');
-    //}
-
+    }
   }
 
   /**

--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -89,11 +89,10 @@ class JoomGalleryViewImages extends JoomGalleryView
       JToolbarHelper::divider();
     }
 
-    //if($canDo->get('core.delete'))
-    //{
+    if($canDo->get('core.delete') || $canDo->get('joom.delete.own'))
+    {
       JToolbarHelper::deleteList('', 'remove');
-    //}
-
+    }
   }
 
   /**

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1716,3 +1716,12 @@ COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_TO_EDIT_IMAGE="You are not allowed to edi
 ;-------
 COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY="If you want to delete all selected categories which still contain images or sub-categories please push the button below."
 COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL="Delete completely"
+;------------------------------------------------------------------------------------
+; Deleted, new or changed constants since JoomGallery 3.6.0
+;------------------------------------------------------------------------------------
+;New
+;-------
+COM_JOOMGALLERY_ACTION_DELETE_OWN="Delete Own"
+COM_JOOMGALLERY_ACTION_COMPONENT_DELETE_OWN_DESC="Allow users in the group to delete their own categories or images."
+COM_JOOMGALLERY_ACTION_CATEGORY_DELETE_OWN_DESC="New setting for <strong>delete own actions</strong> in this category and the calculated setting based on the parent category or the extension setting and group permissions."
+COM_JOOMGALLERY_ACTION_IMAGE_DELETE_OWN_DESC="New setting for <strong>delete own actions</strong> on this image and the calculated setting based on the category and group permissions."

--- a/administrator/language/en-GB/en-GB.com_joomgallery.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.sys.ini
@@ -66,3 +66,7 @@ COM_JOOMGALLERY_ACTION_COMPONENT_UPLOAD_DESC="Allow users in the group to upload
 COM_JOOMGALLERY_ACTION_COMPONENT_UPLOAD_INOWN_DESC="Allow users in the group to upload images into their own categories."
 COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_DESC="Allow users in the group to create categories in this extension."
 COM_JOOMGALLERY_ACTION_COMPONENT_CREATE_INOWN_DESC="Allow users in the group to create categories in their own categories."
+;-------
+; New since JoomGallery 3.6.0
+COM_JOOMGALLERY_ACTION_DELETE_OWN="Delete Own"
+COM_JOOMGALLERY_ACTION_COMPONENT_DELETE_OWN_DESC="Allow users in the group to delete their own categories or images."

--- a/components/com_joomgallery/models/edit.php
+++ b/components/com_joomgallery/models/edit.php
@@ -486,7 +486,8 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $row->load($this->_id);
 
     // Check whether we are allowed to delete this image
-    if(!$this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$row->id))
+    if(   !$this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$row->id)
+      && (!$this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$row->id) || !$row->owner || $row->owner != $this->_user->get('id')))
     {
       throw new RuntimeException(JText::_('COM_JOOMGALLERY_IMAGE_MSG_DELETE_NOT_PERMITTED'));
     }

--- a/components/com_joomgallery/models/editcategory.php
+++ b/components/com_joomgallery/models/editcategory.php
@@ -595,7 +595,8 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     $row->load($this->_id);
 
     // Check whether we are allowed to delete this category
-    if(!$this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$this->_id))
+    if(   !$this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$this->_id) 
+      && (!$this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.category.'.$this->_id) || !$row->owner || $row->owner != $this->_user->get('id')))
     {
       throw new RuntimeException(JText::_('COM_JOOMGALLERY_CATEGORY_MSG_DELETE_NOT_PERMITTED'));
     }

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -814,7 +814,8 @@ class JoomGalleryViewCategory extends JoomGalleryView
           $images[$key]->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$images[$key]->id))
+        if(   $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$images[$key]->id)
+          || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$images[$key]->id) && $images[$key]->owner && $images[$key]->owner == $this->_user->get('id')))
         {
           $images[$key]->show_delete_icon = true;
         }

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -773,7 +773,8 @@ class JoomGalleryViewDetail extends JoomGalleryView
           $params->set('show_edit_icon', 1);
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$image->id))
+        if(   $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$image->id)
+          || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$image->id) && $image->imgowner && $image->imgowner == $this->_user->get('id')))
         {
           $params->set('show_delete_icon', 1);
         }

--- a/components/com_joomgallery/views/favourites/view.html.php
+++ b/components/com_joomgallery/views/favourites/view.html.php
@@ -129,7 +129,8 @@ class JoomGalleryViewFavourites extends JoomGalleryView
           $row->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$row->id))
+        if(   $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$row->id)
+          || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$row->id) && $row->imgowner == $this->_user->get('id')))
         {
           $row->show_delete_icon = true;
         }

--- a/components/com_joomgallery/views/search/view.html.php
+++ b/components/com_joomgallery/views/search/view.html.php
@@ -132,7 +132,8 @@ class JoomGalleryViewSearch extends JoomGalleryView
           $rows[$key]->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id))
+        if(   $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id)
+          || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$rows[$key]->id) && $rows[$key]->owner == $this->_user->get('id')))
         {
           $rows[$key]->show_delete_icon = true;
         }

--- a/components/com_joomgallery/views/toplist/view.html.php
+++ b/components/com_joomgallery/views/toplist/view.html.php
@@ -199,7 +199,8 @@ class JoomGalleryViewToplist extends JoomGalleryView
           $rows[$key]->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id))
+        if(   $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id)
+          || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$rows[$key]->id) && $rows[$key]->owner == $this->_user->get('id')))
         {
           $rows[$key]->show_delete_icon = true;
         }

--- a/components/com_joomgallery/views/usercategories/tmpl/default.php
+++ b/components/com_joomgallery/views/usercategories/tmpl/default.php
@@ -135,12 +135,13 @@ $sortFields = $this->getSortFields();
         $originalOrders     = array();
         $allowed_categories = $this->_ambit->getCategoryStructure();
         foreach($this->items as $i => $item):
-          $orderkey   = array_search($item->cid, $this->ordering[$item->parent_id]);
-          $canEdit    = $this->_user->authorise('core.edit', _JOOM_OPTION.'.category.'.$item->cid);
-          $canEditOwn = $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.category.'.$item->cid) && $item->owner && $item->owner == $this->_user->get('id');
-          $canChange  = $this->_user->authorise('core.edit.state', _JOOM_OPTION.'.category.'.$item->cid);
-          $canDelete  = $this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$item->cid);
-          $canView    = isset($allowed_categories[$item->cid]);
+          $orderkey     = array_search($item->cid, $this->ordering[$item->parent_id]);
+          $canEdit      = $this->_user->authorise('core.edit', _JOOM_OPTION.'.category.'.$item->cid);
+          $canEditOwn   = $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.category.'.$item->cid) && $item->owner && $item->owner == $this->_user->get('id');
+          $canChange    = $this->_user->authorise('core.edit.state', _JOOM_OPTION.'.category.'.$item->cid);
+          $canDelete    = $this->_user->authorise('core.delete', _JOOM_OPTION.'.category.'.$item->cid);
+          $canDeleteOwn = $this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.category.'.$item->cid) && $item->owner && $item->owner == $this->_user->get('id');
+          $canView      = isset($allowed_categories[$item->cid]);
 
           // Get the parents of item for sorting
           if ($item->level > 1)
@@ -223,7 +224,7 @@ $sortFields = $this->getSortFields();
                   <?php echo JHTML::_('joomgallery.icon', 'edit.png', 'COM_JOOMGALLERY_COMMON_EDIT_CATEGORY_TIPCAPTION'); ?></a>
               </div>
 <?php       endif;
-            if($canDelete && !$item->children && !$item->images): ?>
+            if(($canDelete || $canDeleteOwn) && !$item->children && !$item->images): ?>
               <div class="pull-left<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DELETE_CATEGORY_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DELETE_CATEGORY_TIPCAPTION'); ?>">
                 <a href="javascript:if (confirm('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_SURE_DELETE_SELECTED_ITEM', true); ?>')){ location.href='<?php echo JRoute::_('index.php?task=category.delete&catid='.$item->cid.$this->slimitstart, false); ?>';}">
                   <?php echo JHTML::_('joomgallery.icon', 'edit_trash.png', 'COM_JOOMGALLERY_COMMON_DELETE'); ?></a>

--- a/components/com_joomgallery/views/userpanel/view.html.php
+++ b/components/com_joomgallery/views/userpanel/view.html.php
@@ -181,7 +181,8 @@ class JoomGalleryViewUserpanel extends JoomGalleryView
         $this->items[$key]->show_edit_icon = true;
       }
 
-      if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$this->items[$key]->id))
+      if (  $this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$this->items[$key]->id) 
+        || ($this->_user->authorise('joom.delete.own', _JOOM_OPTION.'.image.'.$this->items[$key]->id) && $this->items[$key]->owner == $this->_user->get('id')))
       {
         $this->items[$key]->show_delete_icon = true;
       }


### PR DESCRIPTION
At the moment there is only one setting 'delete' in the Joomla ACL. There is no option to limit deletion to 'own' content.

This PR extends the permission in the JoomGallery by the action 'delete own' (joom.delete.own).

This allows users to be given the permission to delete their 'own' categories or images without at the same time being granted the authorization to delete categories or images of other users.

I am very appreciative for suggestions for improvement. 