### PR TITLE
Add a security question in image manager

### DIFF
--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -91,7 +91,7 @@ class JoomGalleryViewImages extends JoomGalleryView
 
     if($this->pagination->total)
     {
-      JToolbarHelper::deleteList('', 'remove');
+      JToolbarHelper::deleteList('COM_JOOMGALLERY_IMGMAN_CONFIRM_DELETE_IMAGES', 'remove');
     }
   }
 

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1720,6 +1720,7 @@ COM_JOOMGALLERY_CATMAN_MSG_DELETECOMPLETELY_BUTTON_LABEL="Delete completely"
 ;------------------------------------------------------------------------------------
 ;New
 ;-------
+COM_JOOMGALLERY_IMGMAN_CONFIRM_DELETE_IMAGES="Are you sure you want to delete all selected images?"
 COM_JOOMGALLERY_ACTION_DELETE_OWN="Delete Own"
 COM_JOOMGALLERY_ACTION_COMPONENT_DELETE_OWN_DESC="Allow users in the group to delete their own categories or images."
 COM_JOOMGALLERY_ACTION_CATEGORY_DELETE_OWN_DESC="New setting for <strong>delete own actions</strong> in this category and the calculated setting based on the parent category or the extension setting and group permissions."


### PR DESCRIPTION
At the moment, the selected images are deleted immediately when you click on Delete in Image Manager.
This can lead to loss of data if delete is accidentally clicked instead of another button.
This PR adds an additional security question.