### PR TITLE
External search engines integration

### DIFF
--- a/administrator/components/com_joomgallery/helpers/config.php
+++ b/administrator/components/com_joomgallery/helpers/config.php
@@ -326,6 +326,7 @@ class JoomConfig extends JObject
   var $jg_showfavouritesdownload;
   var $jg_showfavouriteseditorlinks;
   var $jg_search;
+  var $jg_searchengine;
   var $jg_searchcols;
   var $jg_searchthumbalign;
   var $jg_searchtextalign;

--- a/administrator/components/com_joomgallery/helpers/html/joomselect.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomselect.php
@@ -403,4 +403,39 @@ abstract class JHtmlJoomSelect
 
     return JHtml::_('select.genericlist', $options, $name, $attr, 'value', 'text', $selected);
   }
+
+  /**
+   * Creates a HMTL select list of SearchEngine options
+   *
+   * @param   string  $name         Name of the field
+   * @param   string  $selected     Option that should be preselected.
+   * @param   string  $attr         Optional attributes for the HTML element
+   * @param   array   $extra        Array of additional options for the select list
+   * @return  string  The HTML select list of SearchEngine options
+   * @since   3.0
+   */
+  public static function searchEngine($name, $selected = null, $attr = null, $extra = array())
+  {
+    // Additional options are placed first in the list
+    $options = $extra;
+
+    // Default option
+    $options[] = JHtml::_('select.option', 'joomgallery', JText::_('COM_JOOMGALLERY'));
+
+    // Load plugins in order to search for additional SearchEngine plugins
+    JPluginHelper::importPlugin('joomgallery');
+    $plugins = JDispatcher::getInstance()->trigger('onJoomSearchEngineGetName');
+
+    foreach($plugins as $plugin)
+    {
+      $options[] = JHtml::_('select.option', $plugin);
+    }
+
+    if(!$attr)
+    {
+      $attr = 'class="inputbox" size="'.max(count($options),2).'"';
+    }
+
+    return JHtml::_('select.genericlist', $options, $name, $attr, 'value', 'text', $selected);
+  }
 }

--- a/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
@@ -222,6 +222,7 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_config` (
   `jg_showpathway` int(1) NOT NULL,
   `jg_completebreadcrumbs` int(1) NOT NULL,
   `jg_search` int(1) NOT NULL,
+  `jg_searchengine` varchar(20) NOT NULL DEFAULT 'joomgallery',
   `jg_searchcols` int(1) NOT NULL,
   `jg_searchthumbalign` int(1) NOT NULL,
   `jg_searchtextalign` int(1) NOT NULL,

--- a/administrator/components/com_joomgallery/sql/setdefault.install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/setdefault.install.mysql.utf8.sql
@@ -169,6 +169,7 @@ INSERT IGNORE INTO `#__joomgallery_config`
 
   /* --> ### Search ####*/
   /*jg_search*/                     1,
+  /*jg_searchengine*/               'joomgallery',
   /*jg_searchcols*/                 1,
   /*jg_searchthumbalign*/           1,
   /*jg_searchtextalign*/            1,

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.6.0.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.6.0.sql
@@ -7,3 +7,4 @@ ALTER TABLE `#__joomgallery_config` ADD `jg_detailautorot` int(1) NOT NULL DEFAU
 ALTER TABLE `#__joomgallery_config` ADD `jg_thumbautorot` int(1) NOT NULL DEFAULT 0 AFTER `jg_thumbheight`;
 ALTER TABLE `#__joomgallery_config` DROP `jg_upload_exif_rotation`;
 ALTER TABLE `#__joomgallery_config` DROP `jg_dyncropbgcol`;
+ALTER TABLE `#__joomgallery_config` ADD `jg_searchengine` varchar(20) NOT NULL DEFAULT 'joomgallery' AFTER `jg_search`;

--- a/administrator/components/com_joomgallery/views/config/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/config/tmpl/default.php
@@ -1085,6 +1085,8 @@ echo JHtml::_('tabs.start', 'NestedPaneTen', array('useCookie' => 1));
 echo JHtml::_('tabs.panel', JText::_('COM_JOOMGALLERY_CONFIG_COMMON_TAB_GENERAL_SETTINGS'), 'nested-thirtythree');
 
 JHTML::_('joomconfig.start', 'page33');
+    $mc_jg_searchengine = JHtml::_('joomselect.searchEngine', 'jg_searchengine', $this->_config->get('jg_searchengine'));
+    JHTML::_('joomconfig.row', 'jg_searchengine', 'custom', 'COM_JOOMGALLERY_CONFIG_SS_GS_SEARCHENGINE', $mc_jg_searchengine);
     $search[] = JHTML::_('select.option','0', JText::_('COM_JOOMGALLERY_CONFIG_COMMON_OPTION_NO_DISPLAY'));
     $search[] = JHTML::_('select.option','1', JText::_('COM_JOOMGALLERY_CONFIG_COMMON_OPTION_IN_HEADER'));
     $search[] = JHTML::_('select.option','2', JText::_('COM_JOOMGALLERY_CONFIG_COMMON_OPTION_IN_FOOTER'));

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1804,6 +1804,8 @@ COM_JOOMGALLERY_CONFIG_GS_IP_TEST_GENMEMORY_LBL="memory used"
 COM_JOOMGALLERY_CONFIG_GS_IP_TEST_GENMEMORY_TXT="Memory that has been allocated during image manipulation (megabytes)"
 COM_JOOMGALLERY_CONFIG_GS_IP_TEST_QUALITY_LBL="quality"
 COM_JOOMGALLERY_CONFIG_GS_IP_TEST_QUALITY_TXT="Quality parameter used to generate the image"
+COM_JOOMGALLERY_CONFIG_SS_GS_SEARCHENGINE="Choose search engine"
+COM_JOOMGALLERY_CONFIG_SS_GS_SEARCHENGINE_LONG="JoomGallery is shipped it its own engine to search your images. The JoomGallery search engine is a DB query based engine. Your entered search string ends up in principle in a following sql selection statement: SELECT * FROM #__joomgallery WHERE imgtext LIKE %searchstring%.<br /><br />You can extend JoomGallery with more advanced search engines using search plugins (e.g the smart search engine from the Joomla! core). After installing and enabling the search plugins in the plugin manager of Joomla! you will be able to select them here."
 ;-------
 ;Changed
 ;-------

--- a/components/com_joomgallery/models/search.php
+++ b/components/com_joomgallery/models/search.php
@@ -72,14 +72,24 @@ class JoomGalleryModelSearch extends JoomGalleryModel
       // Create query object
       $query = $this->_db->getQuery(true);
 
-      // Create search part of the query
-      $where = '(u.username       LIKE '.$this->_db->q('%'.$searchstring.'%').'
-              OR a.imgtitle       LIKE '.$this->_db->q('%'.$searchstring.'%').'
-              OR LOWER(a.imgtext) LIKE '.$this->_db->q('%'.$searchstring.'%');
+      if($this->_config->get('jg_searchengine') == 'joomgallery')
+      {
+        // Create search part of the query
+        $where   = '(u.username       LIKE '.$this->_db->q('%'.$searchstring.'%').'
+                  OR a.imgtitle       LIKE '.$this->_db->q('%'.$searchstring.'%').'
+                  OR LOWER(a.imgtext) LIKE '.$this->_db->q('%'.$searchstring.'%');
+        $context = _JOOM_OPTION.'.search';
+      }
+      else
+      {
+        $where   = '(';
+        $context = _JOOM_OPTION.'.'.$this->_config->get('jg_searchengine');
+      }
 
       // Add query parts from plugins
-      $aliases = array('images' => 'a', 'categories' => 'ca');
-      $plugins = $this->_mainframe->triggerEvent('onJoomSearch', array($searchstring, $aliases, _JOOM_OPTION.'.search'));
+      $aliases = array('images' => 'a', 'categories' => 'ca', 'users' => 'u');
+      $plugins = $this->_mainframe->triggerEvent('onJoomSearch', array($searchstring, $aliases, $context));
+
       foreach($plugins as $plugin)
       {
         if(isset($plugin['images.select']))
@@ -104,6 +114,7 @@ class JoomGalleryModelSearch extends JoomGalleryModel
       // Only now the search part can be finalized
       $where .= ')';
 
+
       // General select clause of the query
       $query->select('a.*, '.JoomHelper::getSQLRatingClause('a').' AS rating, u.username, ca.cid, ca.name AS name, ca.allow_download AS allow_download');
 
@@ -122,9 +133,12 @@ class JoomGalleryModelSearch extends JoomGalleryModel
       // Main part of the query
       $query->from(_JOOM_TABLE_IMAGES.' AS a')
             ->innerJoin(_JOOM_TABLE_CATEGORIES.' AS ca ON a.catid = ca.cid')
-            ->leftJoin('#__users AS u ON a.owner = u.id')
-            ->where($where)
-            ->where('a.published = 1')
+            ->leftJoin('#__users AS u ON a.owner = u.id');
+      if($this->_config->get('jg_searchengine') == 'joomgallery')
+      {
+        $query->where($where);
+      }
+      $query->where('a.published = 1')
             ->where('a.approved = 1')
             ->where('a.access IN ('.$authorisedViewLevels.')')
             ->where('ca.published = 1')

--- a/components/com_joomgallery/models/search.php
+++ b/components/com_joomgallery/models/search.php
@@ -92,22 +92,31 @@ class JoomGalleryModelSearch extends JoomGalleryModel
 
       foreach($plugins as $plugin)
       {
-        if(isset($plugin['images.select']))
+        $plugin_searchengines = array('joomgallery');
+        if(isset($plugin['searchengines']))
         {
-          $query->select($plugin['images.select']);
+          $plugin_searchengines = $plugin['searchengines'];
         }
-        if(isset($plugin['images.leftjoin']))
-        {
-          $query->leftJoin($plugin['images.leftjoin']);
-        }
-        if(isset($plugin['images.where']))
-        {
-          $query->where($plugin['images.where']);
-        }
-        if(isset($plugin['images.where.or']))
-        {
-          $where .= '
-              OR '.$plugin['images.where.or'];
+
+        if(in_array($this->_config->get('jg_searchengine'), $plugin_searchengines))
+		    {
+          if(isset($plugin['images.select']))
+          {
+            $query->select($plugin['images.select']);
+          }
+          if(isset($plugin['images.leftjoin']))
+          {
+            $query->leftJoin($plugin['images.leftjoin']);
+          }
+          if(isset($plugin['images.where']))
+          {
+            $query->where($plugin['images.where']);
+          }
+          if(isset($plugin['images.where.or']))
+          {
+            $where .= '
+                OR '.$plugin['images.where.or'];
+          }
         }
       }
 


### PR DESCRIPTION
This PR integrates external search engines into JoomGallery. External search engines needs to have a Plugin of group="joomgallery" and the plugin events "onJoomSearchEngineGetName" and "onJoomSearch".
A configuration option is added to the configuration manager. The option is found in the search tab. Any external search engine which has a JoomGallery-Plugin installed and enabled will be listed there in the config manager. There you can select which search engine you want to use to create the search view.
The serach form field in the header of JoomGallery will generate the search view based on the selected search engine.

### Prerequirements
- PR #78 (More plugin events)
- A suitable search plugin (e.g https://github.com/JoomGalleryfriends/JoomFinderPlugin)

### Info
Since this PR depends on the PR #78 I will do a rebase as soon as the PR #78 is merged and change this PR from 'Draft' to 'Ready for review'.