### PR TITLE
Fixes assigning a valid user to an image or category in maintenance manager

### DIFF
--- a/administrator/components/com_joomgallery/views/maintenance/tmpl/default_dbimages.php
+++ b/administrator/components/com_joomgallery/views/maintenance/tmpl/default_dbimages.php
@@ -239,7 +239,7 @@ defined('_JEXEC') or die('Direct Access to this location is not allowed.');
       <input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
       <?php echo JHtml::_('form.token'); ?>
       <?php echo JHTML::_('list.users', 'newuser', 0, true, null, 'name', false); ?>
-      <a href="#correctUser" id="filesave" class="saveorder" title="<?php echo JText::_('COM_JOOMGALLERY_MAIMAN_APPLY'); ?>"></a>
+      <a href="#correctUser" id="filesave" class="btn btn-primary btn-mini"><?php echo JText::_('COM_JOOMGALLERY_MAIMAN_APPLY'); ?></a>
       <span id="usertip"> <?php echo JHTML::_('tooltip', JText::_('COM_JOOMGALLERY_MAIMAN_NOTE_USER_FILTER'), JText::_('COM_JOOMGALLERY_MAIMAN_NOTE')); ?></span>
     </div>
 </form>

--- a/media/joomgallery/js/maintenance.js
+++ b/media/joomgallery/js/maintenance.js
@@ -19,7 +19,7 @@ function joom_selectnewuser(id)
     var task = 'setuser';
   }
 
-  document.id('newuser').inject('correctuser' + id);
+  document.id('newuser_chzn').inject('correctuser' + id);
   document.id('filesave').inject('correctuser' + id);
   document.id('filesave').removeEvents();
   document.id('filesave').addEvent('click', function(){
@@ -31,13 +31,13 @@ function joom_selectbatchjob(job)
 {
   if(job == 'setuser')
   {
-    document.id('newuser').inject('batchjobs');
+    document.id('newuser_chzn').inject('batchjobs');
     document.id('usertip').inject('batchjobs');
     document.id('filesave').inject('garage');
   }
   else
   {
-    document.id('newuser').inject('garage');
+    document.id('newuser_chzn').inject('garage');
     document.id('usertip').inject('garage');
     document.id('filesave').inject('garage');
   }


### PR DESCRIPTION
If the JoomGallery maintanance manager reports certain images or categories having a missing user it is not possible to assign a valid owner to them.
The action button 'Set new user' in the owner colum of the respective tabs is not working at all, with the batch jobs it is just possible to assign 'No User' (means value 0) to the images or categories.
This pull request should fix this problem.