### PR TITLE
Add error code to JError::raiseWarning method

### DIFF
--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -1169,7 +1169,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Make sure the record is valid
     if(!$item->check())
     {
-      JError::raiseWarning($item->getError());
+      JError::raiseWarning(100, $item->getError());
 
       return false;
     }
@@ -1185,7 +1185,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Store the entry to the database
     if(!$item->store())
     {
-      JError::raiseWarning($item->getError());
+      JError::raiseWarning(100, $item->getError());
 
       return false;
     }

--- a/components/com_joomgallery/models/edit.php
+++ b/components/com_joomgallery/models/edit.php
@@ -846,7 +846,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     // Make sure the record is valid
     if(!$item->check())
     {
-      JError::raiseWarning($item->getError());
+      JError::raiseWarning(100, $item->getError());
 
       return false;
     }
@@ -854,7 +854,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     // Store the entry to the database
     if(!$item->store())
     {
-      JError::raiseWarning($item->getError());
+      JError::raiseWarning(100, $item->getError());
 
       return false;
     }


### PR DESCRIPTION
When moving an image, there was a PHP error when modifications could not be written to the database for example if there is an error happening within a Plugin.

`0  Too few arguments to function JError::raiseWarning(), 1 passed in /data/www/www152/www/administrator/components/com_joomgallery/models/image.php on line 1190 and at least 2 expected`

The method [JError::raiseWarning](https://api.joomla.org/cms-3/classes/JError.html#method_raiseWarning) expects the first argument to be an application internal error code. Since JoomGallery does not use this internal error codes, a random error code was inserted in order to get rid of the PHP error and to get the correct error message from the Table object.