### PR TITLE
Fix error when wrong php memory_limit

### DIFF
--- a/administrator/components/com_joomgallery/helpers/imgtools.php
+++ b/administrator/components/com_joomgallery/helpers/imgtools.php
@@ -2323,13 +2323,13 @@ class JoomIMGtools
 
       // Get memory limit in bytes
       $memory_limit = @ini_get('memory_limit');
-      if(!empty($memory_limit) && $memory_limit != 0)
+      if(!empty($memory_limit) && $memory_limit > 1)
       {
         $val          = substr($memory_limit, -1);
         $memory_limit = substr($memory_limit, 0, -1) * $byte_values[$val];
       }
 
-      if($memory_limit != 0 && $memoryNeeded > $memory_limit)
+      if($memory_limit > 1 && $memoryNeeded > $memory_limit)
       {
         $memoryNeededMB = round($memoryNeeded / $byte_values['M'], 0);
         $memoryLimitMB  = round($memory_limit / $byte_values['M'], 0);


### PR DESCRIPTION
The function checkMemory checks the value of memory_limit which is set in php.ini. Some hosters have set a value of -1 here. This 'unusual' value causes the check to fail.
This PR is intended to harden the function against such incorrect values.
![memory_limit_1](https://user-images.githubusercontent.com/9802593/201045853-f951d954-da53-4cde-bf49-b348a6e52d66.jpg)
See [Threat ](https://www.forum.joomgalleryfriends.net/forum/index.php?thread/314-alle-upload-funktionen-klappen-nicht-unter-php-8-0/)in german forum.
