### PR TITLE
Fix vulnerability type SQL Injection

### DIFF
--- a/administrator/components/com_joomgallery/controllers/categories.json.php
+++ b/administrator/components/com_joomgallery/controllers/categories.json.php
@@ -57,6 +57,10 @@ class JoomGalleryControllerCategories extends JoomGalleryController
 		$order          = JRequest::getVar('order',	null, 'post', 'array');
 		$originalOrder  = explode(',', JRequest::getString('original_order_values'));
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($pks, array($pks));
+    JArrayHelper::toInteger($order, array($order));
+
 		// Make sure something has changed
 		if($order !== $originalOrder)
     {

--- a/administrator/components/com_joomgallery/controllers/categories.php
+++ b/administrator/components/com_joomgallery/controllers/categories.php
@@ -61,6 +61,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     $task     = JRequest::getCmd('task');
     $publish  = (int)($task == 'publish');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(empty($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
@@ -117,6 +120,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     $task     = JRequest::getCmd('task');
     $publish  = ($task == 'approve');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(empty($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
@@ -169,6 +175,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
   function remove()
   {
     $ids = JRequest::getVar('cid', array(), '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($ids, array($ids));
 
     $model = $this->getModel('categories');
     try
@@ -422,6 +431,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
   {
     $cid = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($ids, array($ids));
+
     // Direction
     $dir  = 1;
     $task = JRequest::getCmd('task');
@@ -463,6 +475,10 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     $pks            = JRequest::getVar('cid',  null,  'post',  'array');
     $order          = JRequest::getVar('order',  null, 'post', 'array');
     $originalOrder  = explode(',', JRequest::getString('original_order_values'));
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($pks, array($pks));
+    JArrayHelper::toInteger($order, array($order));
 
     // Make sure something has changed
     if($order !== $originalOrder)

--- a/administrator/components/com_joomgallery/controllers/comments.php
+++ b/administrator/components/com_joomgallery/controllers/comments.php
@@ -66,6 +66,9 @@ class JoomGalleryControllerComments extends JoomGalleryController
     $task     = JRequest::getCmd('task');
     $publish  = ($task == 'publish');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(empty($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMAN_MSG_NO_COMMENTS_SELECTED'));
@@ -101,6 +104,9 @@ class JoomGalleryControllerComments extends JoomGalleryController
     $cid      = JRequest::getVar('cid', array(), 'post', 'array');
     $task     = JRequest::getCmd('task');
     $publish  = ($task == 'approve');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
 
     if(empty($cid))
     {

--- a/administrator/components/com_joomgallery/controllers/config.php
+++ b/administrator/components/com_joomgallery/controllers/config.php
@@ -66,6 +66,9 @@ class JoomGalleryControllerConfig extends JoomGalleryController
     $id  = JRequest::getInt('id');
     $cid = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(!$id && count($cid) && $cid[0])
     {
       JRequest::setVar('id', (int) $cid[0]);
@@ -157,6 +160,9 @@ class JoomGalleryControllerConfig extends JoomGalleryController
     $config = JoomConfig::getInstance('admin');
     $cid    = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(!count($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_CONFIGS_NO_ROWS_SELECTED'), 'notice');
@@ -201,6 +207,9 @@ class JoomGalleryControllerConfig extends JoomGalleryController
   {
     $cid = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     // Direction
     $dir  = 1;
     $task = JRequest::getCmd('task');
@@ -230,6 +239,10 @@ class JoomGalleryControllerConfig extends JoomGalleryController
   {
     $cid    = JRequest::getVar('cid', array(0), 'post', 'array');
     $order  = JRequest::getVar('order', array(0), 'post', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+    JArrayHelper::toInteger($order, array($order));
 
     // Create and load the categories table object
     $row = JTable::getInstance('joomgalleryconfig', 'Table');

--- a/administrator/components/com_joomgallery/controllers/images.json.php
+++ b/administrator/components/com_joomgallery/controllers/images.json.php
@@ -37,6 +37,10 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $order = JRequest::getVar('order', array(), 'post', 'array');
     $user  = JFactory::getUser();
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+    JArrayHelper::toInteger($order, array($order));
+
     $row = JTable::getInstance('joomgalleryimages', 'Table');
 
     // Update the ordering for items in the cid array

--- a/administrator/components/com_joomgallery/controllers/images.php
+++ b/administrator/components/com_joomgallery/controllers/images.php
@@ -60,6 +60,9 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $task     = JRequest::getCmd('task');
     $publish  = (int)($task == 'publish');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(empty($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
@@ -115,6 +118,9 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $task     = JRequest::getCmd('task');
     $feature  = (int)($task == 'feature');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(empty($cid))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
@@ -169,6 +175,10 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $cid      = JRequest::getVar('cid', array(), 'post', 'array');
     $task     = JRequest::getCmd('task');
     $publish  = -1;
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if($task == 'approve')
     {
       $publish = 1;
@@ -236,6 +246,10 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $row   = JTable::getInstance('joomgalleryimages', 'Table');
     $cid   = JRequest::getVar('cid', array(), 'post', 'array');
     $unaffected_images = 0;
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     foreach($cid as $key => $id)
     {
       $row->load((int)$id);
@@ -294,6 +308,10 @@ class JoomGalleryControllerImages extends JoomGalleryController
   public function edit()
   {
     $cid = JRequest::getVar('cid', array(), '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     if(count($cid) <= 1)
     {
       if(count($cid))
@@ -491,6 +509,9 @@ class JoomGalleryControllerImages extends JoomGalleryController
   {
     $cid = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     // Direction
     $dir  = 1;
     $task = JRequest::getCmd('task');
@@ -529,6 +550,10 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $cid    = JRequest::getVar('cid', array(), 'post', 'array');
     $order  = JRequest::getVar('order', array (0), 'post', 'array');
     $user   = JFactory::getUser();
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+    JArrayHelper::toInteger($order, array($order));
 
     // Create and load the images table object
     $row = JTable::getInstance('joomgalleryimages', 'Table');
@@ -590,6 +615,9 @@ class JoomGalleryControllerImages extends JoomGalleryController
   {
     $cid    = JRequest::getVar('cid', array(), 'post', 'array');
     $catid  = JRequest::getInt('catid');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
 
     if(!count($cid))
     {

--- a/administrator/components/com_joomgallery/controllers/maintenance.php
+++ b/administrator/components/com_joomgallery/controllers/maintenance.php
@@ -508,6 +508,9 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
     // Load the necessary image IDs
     $cids = JRequest::getVar('cid', array(), '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'), 'error');

--- a/administrator/components/com_joomgallery/models/comments.php
+++ b/administrator/components/com_joomgallery/models/comments.php
@@ -459,6 +459,9 @@ class JoomGalleryModelComments extends JoomGalleryModel
   {
     $cids = JRequest::getVar('cid', array(0), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     $row = $this->getTable('joomgallerycomments');
 
     if(count($cids))

--- a/administrator/components/com_joomgallery/models/editimages.php
+++ b/administrator/components/com_joomgallery/models/editimages.php
@@ -38,6 +38,9 @@ class JoomGalleryModelEditimages extends JoomGalleryModel
   {
     $cid = JRequest::getVar('cid', array(), '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+
     $query = $this->_db->getQuery(true)
           ->select('a.*, c.cid AS category_id, c.name AS category_name, g.title AS groupname')
           ->from(_JOOM_TABLE_IMAGES.' AS a')

--- a/administrator/components/com_joomgallery/models/fields/thumbnail.php
+++ b/administrator/components/com_joomgallery/models/fields/thumbnail.php
@@ -51,6 +51,9 @@ class JFormFieldThumbnail extends JFormField
       // Get category id from request
       $cids   = JRequest::getVar('cid', array(), '', 'array');
 
+      // Sanitize request inputs
+      JArrayHelper::toInteger($cids, array($cids));
+
       if(isset($cids[0]))
       {
         $catid = intval($cids[0]);

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -237,6 +237,9 @@ class JoomGalleryModelImage extends JoomGalleryModel
     if(is_null($params))
     {
       $params = JRequest::getVar('params', array(), 'post', 'array');
+
+      // Sanitize request inputs
+      JArrayHelper::toInteger($params, array($params));
     }
 
     // Check for validation errors

--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -11,6 +11,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\CMS\Filter\InputFilter;
+
 /**
  * Maintenance model
  *

--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -465,14 +465,15 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
 
       return false;
     }
-
-    JArrayHelper::toInteger($cids);
 
     $query = $this->_db->getQuery(true);
 
@@ -647,14 +648,15 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
 
       return false;
     }
-
-    JArrayHelper::toInteger($cids);
 
     if(!$recursion_level)
     {
@@ -1053,6 +1055,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $user = JRequest::getInt('newuser', 0);
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_IMAGES_SELECTED'));
@@ -1060,7 +1065,6 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JArrayHelper::toInteger($cids);
     $cid_string = implode(',', $cids);
 
     // Get selected image IDs
@@ -1149,6 +1153,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $user = JRequest::getInt('newuser', 0);
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_CATEGORIES_SELECTED'));
@@ -1156,7 +1163,6 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JArrayHelper::toInteger($cids);
     $cid_string = implode(',', $cids);
 
     // Get selected category IDs
@@ -1254,6 +1260,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $orphans = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($orphans, array($orphans));
+
     if(!count($orphans))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_MAIMAN_MSG_NO_FILES_SELECTED'));
@@ -1326,6 +1335,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     }
 
     $folders = JRequest::getVar('cid', array(), 'post', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($folders, array($folders));
 
     if(!count($folders))
     {
@@ -1401,6 +1413,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_MAIMAN_MSG_NO_FILES_SELECTED'));
@@ -1463,6 +1478,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     }
 
     $cids = JRequest::getVar('cid', array(), '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
 
     if(!count($cids))
     {
@@ -1586,6 +1604,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     $cids = JRequest::getVar('cid', array(), '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_MAIMAN_OF_MSG_NO_FOLDERS_SELECTED'));
@@ -1647,6 +1668,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     }
 
     $cids = JRequest::getVar('cid', array(), '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
 
     if(!count($cids))
     {
@@ -1760,6 +1784,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_MAIMAN_MSG_NO_FILES_SELECTED'));
@@ -1828,6 +1855,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     $cids = JRequest::getVar('cid', array(), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     if(!count($cids))
     {
       $this->setError(JText::_('COM_JOOMGALLERY_MAIMAN_OF_MSG_NO_FOLDERS_SELECTED'));
@@ -1894,6 +1924,14 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     $cids   = JRequest::getVar('cid', array(), '', 'array');
     $types  = JRequest::getVar('type', array('thumb', 'img', 'orig'), '', 'array');
+
+    // Sanitize request inputs
+    $filter = InputFilter::getInstance();
+    JArrayHelper::toInteger($cids, array($cids));
+    foreach ($types as $key => $type)
+    {
+      $types[$key] = $filter->clean($type, 'cmd');
+    }
 
     if(!count($cids))
     {

--- a/administrator/components/com_joomgallery/models/move.php
+++ b/administrator/components/com_joomgallery/models/move.php
@@ -43,6 +43,9 @@ class JoomGalleryModelMove extends JoomGalleryModel
   {
     $cids = JRequest::getVar('cid', array(0), 'post', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+
     $query = $this->_db->getQuery(true)
           ->select('*')
           ->from(_JOOM_TABLE_IMAGES)

--- a/administrator/components/com_joomgallery/views/editimages/view.html.php
+++ b/administrator/components/com_joomgallery/views/editimages/view.html.php
@@ -32,6 +32,10 @@ class JoomGalleryViewEditimages extends JoomGalleryView
     $items = $this->get('Images');
 
     $cids = JRequest::getVar('cid', array(), '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cids, array($cids));
+    
     $cids = implode(',', $cids);
 
     // Get the form and fill the fields

--- a/components/com_joomgallery/controllers/categories.json.php
+++ b/components/com_joomgallery/controllers/categories.json.php
@@ -57,6 +57,10 @@ class JoomGalleryControllerCategories extends JControllerLegacy
     $order          = JRequest::getVar('order',	null, 'post', 'array');
     $originalOrder  = explode(',', JRequest::getString('original_order_values'));
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($pks, array($pks));
+    JArrayHelper::toInteger($order, array($order));
+
     // Make sure something has changed
     if($order !== $originalOrder)
     {

--- a/components/com_joomgallery/controllers/image.php
+++ b/components/com_joomgallery/controllers/image.php
@@ -31,6 +31,9 @@ class JoomGalleryControllerImage extends JControllerLegacy
 
     $array = JRequest::getVar('id',  0, '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($array, array($array));
+
     $model->setId((int)$array[0]);
 
     /*$data = JRequest::get('post');
@@ -122,6 +125,9 @@ class JoomGalleryControllerImage extends JControllerLegacy
 
     $array = JRequest::getVar('id',  0, '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($array, array($array));
+
     $model->setId((int)$array[0]);
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
@@ -168,6 +174,9 @@ class JoomGalleryControllerImage extends JControllerLegacy
     $model = $this->getModel('edit');
 
     $array = JRequest::getVar('id',  0, '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($array, array($array));
 
     $model->setId((int)$array[0]);
 

--- a/components/com_joomgallery/controllers/images.json.php
+++ b/components/com_joomgallery/controllers/images.json.php
@@ -37,6 +37,10 @@ class JoomGalleryControllerImages extends JControllerLegacy
     $order = JRequest::getVar('order', array(), 'post', 'array');
     $user  = JFactory::getUser();
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($cid, array($cid));
+    JArrayHelper::toInteger($order, array($order));
+
     $row = JTable::getInstance('joomgalleryimages', 'Table');
 
     // Update the ordering for items in the cid array

--- a/components/com_joomgallery/models/editcategory.php
+++ b/components/com_joomgallery/models/editcategory.php
@@ -53,6 +53,9 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
 
     $array = JRequest::getVar('catid',  0, '', 'array');
 
+    // Sanitize request inputs
+    JArrayHelper::toInteger($array, array($array));
+
     $this->setId($array[0]);
   }
 

--- a/components/com_joomgallery/views/edit/view.html.php
+++ b/components/com_joomgallery/views/edit/view.html.php
@@ -83,6 +83,10 @@ class JoomGalleryViewEdit extends JoomGalleryView
 
     $model = $this->getModel();
     $array = JRequest::getVar('id',  0, '', 'array');
+
+    // Sanitize request inputs
+    JArrayHelper::toInteger($array, array($array));
+
     $model->setId((int)$array[0]);
     $image = $model->getImage();
 


### PR DESCRIPTION
Fixes a security issue in JoomGallery v3.x. 

**Problem:**
`JRequest::getVar('cid', array(), '', 'array');`
This method does not sanitize the input variable properly. At some locations in the code, the retreived input variable was passed directly to the DB which allows attacks of type SQL Injection.