### PR TITLE
Add development warning message

### DIFF
--- a/administrator/components/com_joomgallery/view.php
+++ b/administrator/components/com_joomgallery/view.php
@@ -117,5 +117,16 @@ class JoomGalleryView extends JViewLegacy
         }
       }
     }
+
+    $xml_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'joomgallery.xml';
+    if(JFile::exists($xml_path))
+    {
+      $xml = simplexml_load_file($xml_path);
+      if(\strpos($xml->version, '-dev') || \strpos($xml->version, '-alpha') || \strpos($xml->version, '-beta') || \strpos($xml->version, '-rc'))
+      {
+        // We are dealing with a development version (alpha, beta or rc)
+        $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION'), 'warning');
+      }
+    }    
   }
 }

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1828,5 +1828,5 @@ COM_JOOMGALLERY_MAIMAN_MSG_INC_ALIAS_CATPATH="<i class=\"icon-unpublish\"></i><b
 COM_JOOMGALLERY_MAIMAN_MSG_CATEGORY_RECREATED="Category alias & catpath successfully recreated."
 COM_JOOMGALLERY_MAIMAN_MSG_CATEGORIES_RECREATED="Alias & catpath of %d categories successfully recreated."
 COM_JOOMGALLERY_MAIMAN_CT_OPTION_RECREATE_CAT_ALIAS="Recreate alias & catpath"
-;New with PR "Development hint"
+;New with PR "Add development warning message"
 COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION="This version of JoomGallery is still under development. Do not use this version on a live website. It is intended for testing purposes only..."

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1828,3 +1828,5 @@ COM_JOOMGALLERY_MAIMAN_MSG_INC_ALIAS_CATPATH="<i class=\"icon-unpublish\"></i><b
 COM_JOOMGALLERY_MAIMAN_MSG_CATEGORY_RECREATED="Category alias & catpath successfully recreated."
 COM_JOOMGALLERY_MAIMAN_MSG_CATEGORIES_RECREATED="Alias & catpath of %d categories successfully recreated."
 COM_JOOMGALLERY_MAIMAN_CT_OPTION_RECREATE_CAT_ALIAS="Recreate alias & catpath"
+;New with PR "Development hint"
+COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION="This version of JoomGallery is still under development. Do not use this version on a live website. It is intended for testing purposes only..."

--- a/components/com_joomgallery/view.php
+++ b/components/com_joomgallery/view.php
@@ -128,6 +128,17 @@ class JoomGalleryView extends JViewLegacy
         $this->setLayout($layout);
       }
     }
+
+    $xml_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'joomgallery.xml';
+    if(JFile::exists($xml_path))
+    {
+      $xml = simplexml_load_file($xml_path);
+      if(\strpos($xml->version, '-dev') || \strpos($xml->version, '-alpha') || \strpos($xml->version, '-beta') || \strpos($xml->version, '-rc'))
+      {
+        // We are dealing with a development version (alpha, beta or rc)
+        $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION'), 'warning');
+      }
+    }
   }
 
   /**

--- a/language/en-GB/en-GB.com_joomgallery.ini
+++ b/language/en-GB/en-GB.com_joomgallery.ini
@@ -713,3 +713,5 @@ COM_JOOMGALLERY_COMMON_ALERT_WRONG_EXTENSION="Wrong Filetype! Only .jpg, .jpeg, 
 COM_JOOMGALLERY_UPLOAD_GD_ONLY_JPG_PNG="ERROR: GD can only handle JPG, PNG, GIF and WEBP files!"
 COM_JOOMGALLERY_COMMON_ERROR_ROTATE_ONLY_JPG="ERROR: Rotation failed. GD can only handle JPG, PNG, GIF and WEBP files!"
 COM_JOOMGALLERY_COMMON_ERROR_WATERMARKING_IMAGE="The image %s could not be watermarked."
+;New with PR "Development hint"
+COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION="This version of JoomGallery is still under development. Do not use this version on a live website. It is intended for testing purposes only..."


### PR DESCRIPTION
Adds a warning message to all JoomGallery views if the version in the XML component manifest file contains `-dev`, `-alpha`, `-beta` or`-rc`.
This should warn users to use such versions on productive sites.

![grafik](https://github.com/JoomGalleryfriends/JoomGallery/assets/39154009/1527171a-147d-42ed-b49b-14d0867d1fef)