### PR TITLE
Fix issue during migration: static-path missing

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -361,6 +361,7 @@ COM_JOOMGALLERY_ERROR_FILESYSTEM_ONLY_EMPTY_CAT="Not allowed to change the files
 COM_JOOMGALLERY_ERROR_MOVE_CATEGORY="There was a problem reorganizing the folders in the filesystem when moving the category. Therefore saving the item was canceled. Please check the filesystem manually and fix any discrepancies.<br>Folder path as it should be now: %s<br>Folder path as it should have been: %s"
 COM_JOOMGALLERY_ERROR_RENAME_CATEGORY="There was a problem reorganizing the folders in the filesystem when renaming the category. Therefore saving the item was canceled. Please check the filesystem manually and fix any discrepancies.<br>Folder path as it should be now: %s<br>Folder path as it should have been: %s"
 COM_JOOMGALLERY_ERROR_IMAGE_SAVE_TWO_FILESYSTEMS="Image could not be saved as there are two filesystems involved in saving process. Source filesystem: %s. Destination filesystem: %s."
+COM_JOOMGALLERY_ERROR_CAT_RENAME_AND_MOVE="It is not possible to move a category and change its alias at the same time. Consider perfroming this two operations separately."
 
 ;Mail Templates
 COM_JOOMGALLERY_MAIL_NEWIMAGE_TITLE="JoomGallery: New Image"

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -542,9 +542,17 @@ class CategoryModel extends JoomAdminModel
         // Filesystem changes
 			  $filesystem_success = true;
 
-        if( (!$isNew && $catMoved) || (!$isNew && $aliasChanged) )
+        if(!$isNew && ($catMoved || $aliasChanged))
         {
-          // Action will be performed after storing
+          // Moving and renaming of folders will happen after storing the DB
+          if($catMoved && ($aliasChanged || ($table->alias != $old_table->alias)))
+          {
+            // Moving and renaming folders at the same time is not possible
+            $this->setError(Text::_('COM_JOOMGALLERY_ERROR_CAT_RENAME_AND_MOVE'));
+            $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_CAT_RENAME_AND_MOVE'), 'error', 'jerror');
+
+            return false;
+          }
         }
         elseif($isNew || !$this->component->getConfig()->get('jg_compatibility_mode', 0))
         {

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -546,7 +546,7 @@ class CategoryModel extends JoomAdminModel
         {
           // Action will be performed after storing
         }
-        else
+        elseif($isNew)
         {
           // Create folders
           $filesystem_success = $manager->createCategory($table->alias, $table->parent_id);

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -546,7 +546,7 @@ class CategoryModel extends JoomAdminModel
         {
           // Action will be performed after storing
         }
-        elseif($isNew)
+        elseif($isNew || !$this->component->getConfig()->get('jg_compatibility_mode', 0))
         {
           // Create folders
           $filesystem_success = $manager->createCategory($table->alias, $table->parent_id);

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -487,9 +487,14 @@ class CategoryModel extends JoomAdminModel
           $old_table = clone $table;
         }
 
-        if($table->parent_id != $data['parent_id'] || $data['id'] == 0)
+        if($catMoved || $isNew)
         {
           $table->setLocation($data['parent_id'], 'last-child');
+        }
+        elseif($aliasChanged)
+        {
+          // Make sure paths get updated correctly when alias is changed
+          $table->setLocation($data['parent_id'], '');
         }
 
         // Create file manager service

--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -1310,6 +1310,9 @@ class MigrationModel extends JoomAdminModel
       }
     }
 
+    // Set property to inform we are in migration
+    $table->is_migration = true;
+
     // Change language to 'All' if multilanguage is not enabled
     if($isNew && !Multilanguage::isEnabled())
 		{

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -370,7 +370,13 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     // Create static_path if compatibility mode is activated and we are not in migration
     if(!$this->is_migration && $this->getComponent()->getConfig()->get('jg_compatibility_mode', 0))
     {
-      $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, true);
+      $cat_id = '';
+      if(\preg_match('/_([0-9]+)$/', $this->static_path, $matches))
+      {
+        $cat_id = '_' . (int) $matches[1];
+      }
+
+      $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, true) . $cat_id;
       $this->static_path = $filesystem->cleanPath($this->static_path, '/');
     }
 

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -431,7 +431,10 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
    */
   public function setLocation($referenceId, $position = 'after')
   {
-    parent::setLocation($referenceId, $position);
+    if(!empty($position))
+    {
+      parent::setLocation($referenceId, $position);
+    }
 
     if($referenceId !== 0 && !empty($this->id))
     {

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -367,8 +367,8 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     $this->path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, false);
     $this->path = $filesystem->cleanPath($this->path, '/');
 
-    // Create static_path if compatibility mode is activated
-    if($this->getComponent()->getConfig()->get('jg_compatibility_mode', 0))
+    // Create static_path if compatibility mode is activated and we are not in migration
+    if(!$this->is_migration && $this->getComponent()->getConfig()->get('jg_compatibility_mode', 0))
     {
       $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, true);
       $this->static_path = $filesystem->cleanPath($this->static_path, '/');

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -374,8 +374,8 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
       $static_name = \basename($this->static_path);
       if(\preg_match('/_([0-9]+)$/', $static_name))
       {
-        // We found a numeric value at the end of the folder name e.g alias_6
-        // Therefore we use the static folder name
+        // We found a numeric value at the end of the folder name: e.g alias_6
+        // Therefore we use the static folder name instead
         $alias = $static_name;
       }
 

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -370,13 +370,16 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     // Create static_path if compatibility mode is activated and we are not in migration
     if(!$this->is_migration && $this->getComponent()->getConfig()->get('jg_compatibility_mode', 0))
     {
-      $cat_id = '';
-      if(\preg_match('/_([0-9]+)$/', $this->static_path, $matches))
+      $alias = $this->alias;
+      $static_name = \basename($this->static_path);
+      if(\preg_match('/_([0-9]+)$/', $static_name))
       {
-        $cat_id = '_' . (int) $matches[1];
+        // We found a numeric value at the end of the folder name e.g alias_6
+        // Therefore we use the static folder name
+        $alias = $static_name;
       }
 
-      $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $this->alias, false, true) . $cat_id;
+      $this->static_path = $manager->getCatPath(0, false, $this->parent_id, $alias, false, true);
       $this->static_path = $filesystem->cleanPath($this->static_path, '/');
     }
 

--- a/administrator/com_joomgallery/src/Table/MigrationTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/MigrationTableTrait.php
@@ -19,6 +19,13 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 trait MigrationTableTrait
 {
   /**
+   * True if the table is used during migration
+   *
+   * @var bool
+  */
+  public $is_migration = false;
+  
+  /**
    * True to insert the provided value of the primary key
    * Needed if you want to create a new record with a given ID
    *


### PR DESCRIPTION
This PR fixes the following issue:

### Issue
- Activated compatibility mode
- Migration of an existing Joomla installation (variant 1) with `Use new folder structure = No` and `image usage= Direct usage`

**This results in** 
->the folders remain as they are (i.e. with the id at the end)
->in the DB the field `static_path` is empty