### PR TITLE
Adjustment of the Meta Description

### DIFF
--- a/administrator/com_joomgallery/forms/category.xml
+++ b/administrator/com_joomgallery/forms/category.xml
@@ -176,12 +176,11 @@
 
     <field name="metadesc"
            type="textarea"
-           cols="40"
-           rows="5"
            filter="safehtml"
-           label="JGLOBAL_DESCRIPTION"
-           description="JFIELD_META_DESCRIPTION_LABEL"
-           maxlength="160"
+           label="JFIELD_META_DESCRIPTION_LABEL"
+           rows="3"
+           cols="30"
+           maxlength="300"
            charcounter="true" />
 
     <field name="metakey"

--- a/administrator/com_joomgallery/forms/collection.xml
+++ b/administrator/com_joomgallery/forms/collection.xml
@@ -85,12 +85,11 @@
 
     <field name="metadesc"
            type="textarea"
-           cols="40"
-           rows="5"
            filter="safehtml"
-           label="JGLOBAL_DESCRIPTION"
-           description="JFIELD_META_DESCRIPTION_LABEL"
-           maxlength="160"
+           label="JFIELD_META_DESCRIPTION_LABEL"
+           rows="3"
+           cols="30"
+           maxlength="300"
            charcounter="true" />
 
     <field name="metakey"

--- a/administrator/com_joomgallery/forms/image.xml
+++ b/administrator/com_joomgallery/forms/image.xml
@@ -232,12 +232,11 @@
     <field name="metadesc"
            type="textarea"
            filter="safehtml"
-           rows="5"
-           cols="40"
            default=""
-           label="JGLOBAL_DESCRIPTION"
-           description="JFIELD_META_DESCRIPTION_LABEL"
-           maxlength="160"
+           label="JFIELD_META_DESCRIPTION_LABEL"
+           rows="3"
+           cols="30"
+           maxlength="300"
            charcounter="true"
     />
 

--- a/site/com_joomgallery/forms/categoryform.xml
+++ b/site/com_joomgallery/forms/categoryform.xml
@@ -149,12 +149,11 @@
 
     <field name="metadesc"
            type="textarea"
-           cols="40"
-           rows="5"
            filter="safehtml"
-           label="JGLOBAL_DESCRIPTION"
-           description="JFIELD_META_DESCRIPTION_LABEL"
-           maxlength="160"
+           label="JFIELD_META_DESCRIPTION_LABEL"
+           rows="3"
+           cols="30"
+           maxlength="300"
            charcounter="true" />
 
     <field name="metakey"

--- a/site/com_joomgallery/forms/imageform.xml
+++ b/site/com_joomgallery/forms/imageform.xml
@@ -174,12 +174,11 @@
     <field name="metadesc"
            type="textarea"
            filter="safehtml"
-           rows="5"
-           cols="40"
            default=""
-           label="JGLOBAL_DESCRIPTION"
-           description="JFIELD_META_DESCRIPTION_LABEL"
-           maxlength="160"
+           label="JFIELD_META_DESCRIPTION_LABEL"
+           rows="3"
+           cols="30"
+           maxlength="300"
            charcounter="true"
     />
 


### PR DESCRIPTION
In Joomla! 5 the length of the meta description field has been changed from 160 to 300 characters. See https://github.com/joomla/joomla-cms/pull/41795
This PR adjusts the JoomGallery meta description field so that they match those of Joomla.
```
label="JFIELD_META_DESCRIPTION_LABEL"
rows="3"
cols="30"
maxlength="300"
```
### Testing instructions:
Enter a meta description for categories and images. This may be a maximum of 300 characters long.