### PR TITLE
Multiple image grids and lightGalleries

### DIFF
--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -8,8 +8,6 @@ const defaults = {
         thumbnails: false,
         lightbox_obj: {},
         lightbox_params: {container: 'lightgallery-0-0', selector: '.lightgallery-item'},
-        imgboxclass: 'jg-image',
-        imgclass: 'jg-image-thumb',
         gridclass: 'jg-category',
         infscrollclass: 'infinite-scroll',
         loadmoreid: 'loadMore',
@@ -36,19 +34,6 @@ var callback = function() {
       if(!settings.hasOwnProperty(key) || settings[key] === undefined || settings[key] === null) {
         settings[key] = value;
       }
-    }
-
-    // Add load event listener to images
-    if(settings.layout != 'justified') {
-      var loadImg = function() {
-        this.closest('.' + settings.imgboxclass).classList.add('loaded');
-      }
-
-      let images = Array.from(document.getElementsByClassName(settings.imgclass));
-      console.log(images);
-      images.forEach(image => {
-        image.addEventListener('load', loadImg);
-      });
     }
 
     // Get the grid container
@@ -112,10 +97,10 @@ var callback = function() {
     // Infinity scroll or load more
     if(settings.pagination == 1 && grid || settings.pagination == 2 && grid)
     {
-      const items        = Array.from(grid.getElementsByClassName(settings.imgboxclass));
+      const items        = Array.from(grid.getElementsByClassName('jg-image'));
       const maxImages    = settings.num_columns * 2;
       const loadImages   = settings.num_columns * 3;
-      const hiddenClass  = 'hidden-' + settings.imgboxclass;
+      const hiddenClass  = 'hidden-jg-image';
       const hiddenImages = Array.from(document.getElementsByClassName(hiddenClass));
 
       items.forEach(function (item, index) {

--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -38,6 +38,19 @@ var callback = function() {
       }
     }
 
+    // Add load event listener to images
+    if(settings.layout != 'justified') {
+      var loadImg = function() {
+        this.closest('.' + settings.imgboxclass).classList.add('loaded');
+      }
+
+      let images = Array.from(document.getElementsByClassName(settings.imgclass));
+      console.log(images);
+      images.forEach(image => {
+        image.addEventListener('load', loadImg);
+      });
+    }
+
     // Get the grid container
     const grid = document.querySelector('.' + settings.gridclass);
 

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -281,3 +281,14 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
     </a></p>
   </div>
 <?php endif; ?>
+
+<script>
+  // Add event listener to images
+  let loadImg = function() {
+    this.closest('.jg-image').classList.add('loaded');
+  }
+  let images = Array.from(document.getElementsByClassName('jg-image-thumb'));
+  images.forEach(image => {
+    image.addEventListener('load', loadImg);
+  });
+</script>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -283,12 +283,12 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php endif; ?>
 
 <script>
-  if(window.joomGrid.layout != 'justified') {
+  if(window.joomGrid["1-<?php echo $this->item->id; ?>"].layout != 'justified') {
     var loadImg = function() {
-      this.closest('.' + window.joomGrid.imgboxclass).classList.add('loaded');
+      this.closest('.' + window.joomGrid["1-<?php echo $this->item->id; ?>"].imgboxclass).classList.add('loaded');
     }
 
-    let images = Array.from(document.getElementsByClassName(window.joomGrid.imgclass));
+    let images = Array.from(document.getElementsByClassName(window.joomGrid["1-<?php echo $this->item->id; ?>"].imgclass));
     images.forEach(image => {
       image.addEventListener('load', loadImg);
     });

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -281,16 +281,3 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
     </a></p>
   </div>
 <?php endif; ?>
-
-<script>
-  if(window.joomGrid["1-<?php echo $this->item->id; ?>"].layout != 'justified') {
-    var loadImg = function() {
-      this.closest('.' + window.joomGrid["1-<?php echo $this->item->id; ?>"].imgboxclass).classList.add('loaded');
-    }
-
-    let images = Array.from(document.getElementsByClassName(window.joomGrid["1-<?php echo $this->item->id; ?>"].imgclass));
-    images.forEach(image => {
-      image.addEventListener('load', loadImg);
-    });
-  }  
-</script>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -97,18 +97,19 @@ if(!empty($use_pagination))
 }
 
 // Add and initialize the grid script
-$iniJS  = 'window.joomGrid = {';
-$iniJS .= '  itemid: ' . $this->item->id . ',';
+$iniJS  = 'window.joomGrid["1-'.$this->item->id.'"] = {';
+$iniJS .= '  itemid: "1-' . $this->item->id . '",';
 $iniJS .= '  pagination: ' . $use_pagination . ',';
 $iniJS .= '  layout: "' . $category_class . '",';
 $iniJS .= '  num_columns: ' . $num_columns . ',';
 $iniJS .= '  lightbox: ' . ($lightbox ? 'true' : 'false') . ',';
+$iniJS .= '  lightbox_params: {container: "lightgallery-1-'.$this->item->id.'", selector: ".lightgallery-item"},';
 $iniJS .= '  thumbnails: ' . ($thumbnails ? 'true' : 'false') . ',';
 $iniJS .= '  justified: {height: '.$justified_height.', gap: '.$justified_gap.'}';
 $iniJS .= '};';
 
-$wa->addInlineScript($iniJS, ['position' => 'before'], [], ['com_joomgallery.joomgrid']);
 $wa->useScript('com_joomgallery.joomgrid');
+$wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joomgrid']);
 
 // Permission checks
 $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.category', $this->item->id);
@@ -236,7 +237,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <?php endif; ?>
 
   <?php // Display data array for layout
-    $imgsData = [ 'id' => (int) $this->item->id, 'layout' => $category_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,
+    $imgsData = [ 'id' => '1-'.$this->item->id, 'layout' => $category_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,
                   'caption_align' => $caption_align, 'image_class' => $image_class, 'image_type' => $image_type, 'lightbox_type' => $lightbox_image, 'image_link' => $image_link,
                   'image_title' => (bool) $show_title, 'title_link' => $title_link, 'image_desc' => (bool) $show_description, 'image_date' => (bool) $show_imgdate,
                   'image_author' => (bool) $show_imgauthor, 'image_tags' => (bool) $show_tags

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -53,17 +53,18 @@ if($image_link == 'lightgallery')
 }
 
 // Add and initialize the grid script
-$iniJS  = 'window.joomGrid = {';
-$iniJS .= '  itemid: ' . $this->item->id . ',';
+$iniJS  = 'window.joomGrid["1-'.$this->item->id.'"] = {';
+$iniJS .= '  itemid: "1-' . $this->item->id . '",';
 $iniJS .= '  pagination: 0,';
 $iniJS .= '  layout: "' . $gallery_class . '",';
 $iniJS .= '  num_columns: ' . $num_columns . ',';
 $iniJS .= '  lightbox: ' . ($lightbox ? 'true' : 'false') . ',';
+$iniJS .= '  lightbox_params: {container: "lightgallery-1-'.$this->item->id.'", selector: ".lightgallery-item"},';
 $iniJS .= '  justified: {height: '.$justified_height.', gap: '.$justified_gap.'}';
 $iniJS .= '};';
 
-$wa->addInlineScript($iniJS, ['position' => 'before'], [], ['com_joomgallery.joomgrid']);
 $wa->useScript('com_joomgallery.joomgrid');
+$wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joomgrid']);
 ?>
 
 <div class="com-joomgallery-gallery">
@@ -91,7 +92,7 @@ $wa->useScript('com_joomgallery.joomgrid');
     <p><?php echo Text::_('COM_JOOMGALLERY_GALLERY_NO_IMAGES') ?></p>
   <?php else: ?>
     <?php // Display data array for grid layout
-    $imgsData = [ 'id' => (int) $this->item->id, 'layout' => $gallery_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,
+    $imgsData = [ 'id' => '1-'.$this->item->id, 'layout' => $gallery_class, 'items' => $this->item->images->items, 'num_columns' => (int) $num_columns,
                   'caption_align' => 'center', 'image_class' => $image_class, 'image_type' => $image_type, 'lightbox_type' => $lightbox_image, 'image_link' => $image_link,
                   'image_title' => false, 'title_link' => 'defaultview', 'image_desc' => false, 'image_date' => false,
                   'image_author' => false, 'image_tags' => false

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -114,3 +114,14 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
     </div>
   <?php endif; ?>
 </div>
+
+<script>
+  // Add event listener to images
+  let loadImg = function() {
+    this.closest('.jg-image').classList.add('loaded');
+  }
+  let images = Array.from(document.getElementsByClassName('jg-image-thumb'));
+  images.forEach(image => {
+    image.addEventListener('load', loadImg);
+  });
+</script>

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -115,15 +115,15 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
   <?php endif; ?>
 
   <script>
-    if(window.joomGrid.layout != 'justified') {
+    if(window.joomGrid["1-<?php echo $this->item->id; ?>"].layout != 'justified') {
       var loadImg = function() {
-        this.closest('.' + window.joomGrid.imgboxclass).classList.add('loaded');
+        this.closest('.' + window.joomGrid["1-<?php echo $this->item->id; ?>"].imgboxclass).classList.add('loaded');
       }
 
-      let images = Array.from(document.getElementsByClassName(window.joomGrid.imgclass));
+      let images = Array.from(document.getElementsByClassName(window.joomGrid["1-<?php echo $this->item->id; ?>"].imgclass));
       images.forEach(image => {
         image.addEventListener('load', loadImg);
       });
-    }
+    }  
   </script>
 </div>

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -113,17 +113,4 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
       </a></p>
     </div>
   <?php endif; ?>
-
-  <script>
-    if(window.joomGrid["1-<?php echo $this->item->id; ?>"].layout != 'justified') {
-      var loadImg = function() {
-        this.closest('.' + window.joomGrid["1-<?php echo $this->item->id; ?>"].imgboxclass).classList.add('loaded');
-      }
-
-      let images = Array.from(document.getElementsByClassName(window.joomGrid["1-<?php echo $this->item->id; ?>"].imgclass));
-      images.forEach(image => {
-        image.addEventListener('load', loadImg);
-      });
-    }  
-  </script>
 </div>


### PR DESCRIPTION
This PR adds the possibility to add multiple grid views and lightGallery slideshows on one page.
This comes very handy when having a content plugin and/or image modules appearing at the same page.

### How to test this PR
- Component views, gallery view and category view, should still work as before.
- With a component Plugin (e.g JoomPlu), add multiple images or category walls in one article.
--> They should properly show up and having individual lightGalleries (slideshows).