### PR TITLE
Changed variable names and but not the property name for 'manualy' -> 'manually'

### DIFF
--- a/plugins/system/joomowner/language/en-GB/plg_system_joomowner.ini
+++ b/plugins/system/joomowner/language/en-GB/plg_system_joomowner.ini
@@ -6,7 +6,7 @@ PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_DESC="Select user to be put in place of the d
 PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_LABEL="Search user ID"
 PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_DESC="The user ID entered here will be searched and replaced by the fallback user."
 
-PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
+PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALLY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
 PLG_SYSTEM_JOOMOWNER_ERROR_FALLBACK_USER_CONNECTED_MSG="The user has been set as a fallback and therefore cannot be deleted. <br />Please change before in the <a class=\"alert-link\" href=\"/administrator/index.php?option=com_plugins&view=plugins&filter[element]=joomowner\">plugin settings</a>!"
 PLG_SYSTEM_JOOMOWNER_ERROR_USER_NOT_DELETED_MSG="The user was not deleted!"
 PLG_SYSTEM_JOOMOWNER_USER_DELETED_MSG="For the all JoomGallery %s with IDs '%s', the old user ID '%d' has been replaced with the fallback user ID '%d'."

--- a/plugins/system/joomowner/language/en-GB/plg_system_joomowner.sys.ini
+++ b/plugins/system/joomowner/language/en-GB/plg_system_joomowner.sys.ini
@@ -6,7 +6,7 @@ PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_DESC="Select user to be put in place of the d
 PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_LABEL="Search user ID"
 PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_DESC="The user ID entered here will be searched and replaced by the fallback user."
 
-PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
+PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALLY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
 PLG_SYSTEM_JOOMOWNER_ERROR_FALLBACK_USER_CONNECTED_MSG="The user has been set as a fallback and therefore cannot be deleted. <br />Please change before in the <a class=\"alert-link\" href=\"/administrator/index.php?option=com_plugins&view=plugins&filter[element]=joomowner\">plugin settings</a>!"
 PLG_SYSTEM_JOOMOWNER_ERROR_USER_NOT_DELETED_MSG="The user was not deleted!"
 PLG_SYSTEM_JOOMOWNER_USER_DELETED_MSG="For the all JoomGallery %s with IDs '%s', the old user ID '%d' has been replaced with the fallback user ID '%d'."

--- a/plugins/system/joomowner/src/Extension/JoomgalleryOwner.php
+++ b/plugins/system/joomowner/src/Extension/JoomgalleryOwner.php
@@ -191,7 +191,7 @@ final class JoomgalleryOwner extends CMSPlugin implements SubscriberInterface
     $typeAlias = isset($table->typeAlias) ? $table->typeAlias : $context;
     if(!$ownerField = $this->guessType($typeAlias))
     {
-      // We couldnt guess the type of content we are dealing with
+      // We couldn't guess the type of content we are dealing with
       $this->setResult($event, true);
 
       return;
@@ -217,6 +217,9 @@ final class JoomgalleryOwner extends CMSPlugin implements SubscriberInterface
    */
   public function onContentBeforeSave(Event $event)
   {
+		$test = "";
+		echo "ajax ?";
+
     if(\version_compare(JVERSION, '5.0.0', '<'))
     {
       // Joomla 4
@@ -232,28 +235,28 @@ final class JoomgalleryOwner extends CMSPlugin implements SubscriberInterface
     if($context == 'com_plugins.plugin' && $table->name == 'plg_system_joomowner')
     {
       $newParams             = new Registry($table->params);
-      $userIdToChangeManualy = $newParams->get('userIdToChangeManualy', '');
+      $userIdToChangeManually = $newParams->get('userIdToChangeManualy', '');
 
       // Reset the fields
       $newParams->set('userIdToChangeManualy', '');
       $table->params = (string) $newParams;
 
-      if(empty($userIdToChangeManualy))
+      if(empty($userIdToChangeManually))
       {
         return;
       }
 
-      if($this->isUserExists($userIdToChangeManualy))
+      if($this->isUserExists($userIdToChangeManually))
       {
-        $this->app->enqueueMessage(Text::sprintf('PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALY_EXISTS', $userIdToChangeManualy), 'error');
+        $this->app->enqueueMessage(Text::sprintf('PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALLY_EXISTS', $userIdToChangeManually), 'error');
 
         return;
       }
 
-      if(!empty($userIdToChangeManualy))
+      if(!empty($userIdToChangeManually))
       {
         $this->params = $newParams;
-        $user = array('id' => $userIdToChangeManualy);
+        $user = array('id' => $userIdToChangeManually);
 
         $this->changeUser($user);
       }
@@ -271,7 +274,7 @@ final class JoomgalleryOwner extends CMSPlugin implements SubscriberInterface
     $typeAlias = isset($table->typeAlias) ? $table->typeAlias : $context;
     if(!$ownerField = $this->guessType($typeAlias))
     {
-      // We couldnt get the owner field. It probably does not exist.
+      // We couldn't get the owner field. It probably does not exist.
 		  $this->setResult($event, true);
 
       return;


### PR DESCRIPTION
What shall we do if the complete project uses word 'manualy' instead of 'manually' ?
I changed variabl names , language name but no config names.
No code change intended

This is my first pull request on github and mostly to test the data highway working
This pull request may be deleted without needing my consent. It was just an execise
