### PR TITLE
Fix button layout in control panel

### DIFF
--- a/administrator/com_joomgallery/src/View/Control/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Control/HtmlView.php
@@ -85,27 +85,27 @@ class HtmlView extends JoomGalleryView
     $toolbar = Toolbar::getInstance('toolbar');
 
     // Images button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=images" class="btn btn-primary"><span class="icon-images" title="'.Text::_('COM_JOOMGALLERY_IMAGES').'"></span> '.Text::_('COM_JOOMGALLERY_IMAGES').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=images" class="btn btn-primary"><span class="icon-images" title="'.Text::_('COM_JOOMGALLERY_IMAGES').'"></span> '.Text::_('COM_JOOMGALLERY_IMAGES').'</a></joomla-toolbar-button>';
     $toolbar->appendButton('Custom', $html);
 
     // Multiple add button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=image&amp;layout=upload" class="btn btn-primary"><span class="icon-upload" title="'.Text::_('Upload').'"></span> '.Text::_('Upload').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=image&amp;layout=upload" class="btn btn-primary"><span class="icon-upload" title="'.Text::_('Upload').'"></span> '.Text::_('Upload').'</a></joomla-toolbar-button>';
     $toolbar->appendButton('Custom', $html);
 
     // Categories button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=categories" class="button-folder-open btn btn-primary"><span class="icon-folder-open" title="'.Text::_('JCATEGORIES').'"></span> '.Text::_('JCATEGORIES').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=categories" class="button-folder-open btn btn-primary"><span class="icon-folder-open" title="'.Text::_('JCATEGORIES').'"></span> '.Text::_('JCATEGORIES').'</a></joomla-toolbar-button>';
     $toolbar->appendButton('Custom', $html);
 
     // Tags button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=tags" class="btn btn-primary"><span class="icon-tags" title="'.Text::_('COM_JOOMGALLERY_TAGS').'"></span> '.Text::_('COM_JOOMGALLERY_TAGS').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=tags" class="btn btn-primary"><span class="icon-tags" title="'.Text::_('COM_JOOMGALLERY_TAGS').'"></span> '.Text::_('COM_JOOMGALLERY_TAGS').'</a></joomla-toolbar-button>';
     $toolbar->appendButton('Custom', $html);
 
     // Configs button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=configs" class="btn btn-primary"><span class="icon-sliders-h" title="'.Text::_('COM_JOOMGALLERY_CONFIG_SETS').'"></span> '.Text::_('COM_JOOMGALLERY_CONFIG_SETS').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=configs" class="btn btn-primary"><span class="icon-sliders-h" title="'.Text::_('COM_JOOMGALLERY_CONFIG_SETS').'"></span> '.Text::_('COM_JOOMGALLERY_CONFIG_SETS').'</a></joomla-toolbar-button>';
     $toolbar->appendButton('Custom', $html);
 
     // Maintenance button
-    $html = '<a href="index.php?option=com_joomgallery&amp;view=faulties" class="btn btn-primary"><span class="icon-wrench" title="'.Text::_('COM_JOOMGALLERY_MAINTENANCE').'"></span> '.Text::_('COM_JOOMGALLERY_MAINTENANCE').'</a>';
+    $html = '<joomla-toolbar-button><a href="index.php?option=com_joomgallery&amp;view=faulties" class="btn btn-primary"><span class="icon-wrench" title="'.Text::_('COM_JOOMGALLERY_MAINTENANCE').'"></span> '.Text::_('COM_JOOMGALLERY_MAINTENANCE').'</a></joomla-toolbar-button>';
     // $toolbar->appendButton('Custom', $html);
 
     if($this->getAcl()->checkACL('core.admin'))

--- a/administrator/com_joomgallery/tmpl/control/default.php
+++ b/administrator/com_joomgallery/tmpl/control/default.php
@@ -34,7 +34,7 @@ if(strpos(strtolower(Factory::getApplication()->getLanguage()->getTag()), 'de') 
 <div class="d-flex flex-row">
   <div class="flex-fill">
     <div id="j-main-container" class="j-main-container">
-      <div class"jg-control-head">
+      <div class="jg-control-head">
         <?php // echo 'Kopfbereich für wichtige Meldungen.'; ?>
       </div>
       <div class="card jg-controlpanel-content">
@@ -113,7 +113,7 @@ if(strpos(strtolower(Factory::getApplication()->getLanguage()->getTag()), 'de') 
       <hr>
 
       <?php // Display Footer ?>
-      <div class"jg-control-footer">
+      <div class="jg-control-footer">
         <?php
         // Display copyright ?>
         <div class="row">


### PR DESCRIPTION
Fix for issue https://github.com/JoomGalleryfriends/JoomGallery/issues/196
In addition, a missing equals sign is added in the tmpl file.

### Before this PR
The buttons in the toolbar have no space to each other 

### After this PR
The buttons have the normal spacing