### PR TITLE
[Chore] Remove Joomla 6 deprecations

### DIFF
--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -117,7 +117,7 @@ if(!$readonly)
 		)
 	);
 
-	Factory::getDocument()->getWebAssetManager()
+	Factory::getApplication()->getDocument()->getWebAssetManager()
 		->useScript('com_joomgallery.field-category');
 }
 ?>

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgimage.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgimage.php
@@ -125,7 +125,7 @@ if(!$readonly)
 		)
 	);
 
-	Factory::getDocument()->getWebAssetManager()
+	Factory::getApplication()->getDocument()->getWebAssetManager()
 		->useScript('com_joomgallery.field-image');
 }
 ?>

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgtag.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgtag.php
@@ -114,7 +114,7 @@ if ($readonly) {
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()
+Factory::getApplication()->getDocument()->getWebAssetManager()
     ->usePreset('choicesjs')
     ->useScript('webcomponent.field-fancy-select');
 

--- a/administrator/com_joomgallery/src/Controller/CategoriesController.php
+++ b/administrator/com_joomgallery/src/Controller/CategoriesController.php
@@ -64,7 +64,7 @@ class CategoriesController extends JoomAdminController
         $this->setMessage(Text::_('COM_JOOMGALLERY_ITEM_SUCCESS_DUPLICATED'));
       }
     }
-    catch (Exception $e)
+    catch (\Exception $e)
     {
       $this->component->addLog($e->getMessage(), 'warning', 'jerror');
 

--- a/administrator/com_joomgallery/src/Controller/ConfigsController.php
+++ b/administrator/com_joomgallery/src/Controller/ConfigsController.php
@@ -29,7 +29,7 @@ class ConfigsController extends JoomAdminController
 	 *
 	 * @return  void
 	 *
-	 * @throws  Exception
+	 * @throws  \Exception
 	 */
 	public function duplicate()
 	{

--- a/administrator/com_joomgallery/src/Controller/DisplayController.php
+++ b/administrator/com_joomgallery/src/Controller/DisplayController.php
@@ -15,7 +15,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
 use \Joomla\CMS\Factory;
 use \Joomla\Input\Input;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\Path;
 use \Joomla\CMS\Application\CMSApplication;
 use \Joomla\CMS\MVC\Controller\BaseController;
 use \Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -64,7 +64,7 @@ class DisplayController extends BaseController
    *
    * @since   4.0.0
    */
-  public function __construct($config = array(), MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+  public function __construct($config = array(), ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
   {
     parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/com_joomgallery/src/Controller/ImageController.php
+++ b/administrator/com_joomgallery/src/Controller/ImageController.php
@@ -12,6 +12,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 // No direct access
 \defined('_JEXEC') or die;
 
+use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Router\Route;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Response\JsonResponse;

--- a/administrator/com_joomgallery/src/Controller/ImagesController.php
+++ b/administrator/com_joomgallery/src/Controller/ImagesController.php
@@ -41,7 +41,7 @@ class ImagesController extends JoomAdminController
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct($config = array(), MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+	public function __construct($config = array(), ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
 	{
     parent::__construct($config, $factory, $app, $input);
 
@@ -126,7 +126,7 @@ class ImagesController extends JoomAdminController
         $this->component->addLog(Text::_('COM_JOOMGALLERY_ITEM_SUCCESS_DUPLICATED'), 'info', 'jerror');
       }
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			$this->component->addLog($e->getMessage(), 'warning', 'jerror');
 

--- a/administrator/com_joomgallery/src/Controller/JoomAdminController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomAdminController.php
@@ -13,7 +13,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use \Joomla\Input\Input;
-use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\User\CurrentUserInterface;
 use \Joomla\CMS\Application\CMSApplication;
 use \Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -67,7 +66,7 @@ class JoomAdminController extends BaseAdminController
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct($config = array(), MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+	public function __construct($config = array(), ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
 	{
 		parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/com_joomgallery/src/Controller/JoomFormController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomFormController.php
@@ -68,7 +68,7 @@ class JoomFormController extends BaseFormController
    *
    * @since   4.0.0
    */
-  public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null, FormFactoryInterface $formFactory = null)
+  public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null, ?FormFactoryInterface $formFactory = null)
   {
     parent::__construct($config, $factory, $app, $input, $formFactory);
 

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -80,7 +80,7 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
    *
    * @since   4.0.0
    */
-  public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null, FormFactoryInterface $formFactory = null)
+  public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null, ?FormFactoryInterface $formFactory = null)
   {
     parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -311,7 +311,7 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
 
     // Check if migration item is checked out
     $user  = Factory::getUser();
-    if(isset($item->checked_out) && !($item->checked_out == 0 || $item->checked_out == $user->get('id')))
+    if(isset($item->checked_out) && !($item->checked_out == 0 || $item->checked_out == $user->id))
     {
       // You are not allowed to resume the migration, since it is checked out by another user
       $this->setMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_CHECKED_OUT_BY_ANOTHER_USER', $user->get('name')), 'error');
@@ -397,7 +397,7 @@ class MigrationController extends BaseController implements FormFactoryAwareInte
 
       // Check if migration item is checked out
       $user  = Factory::getUser();
-      if(isset($item->checked_out) && !($item->checked_out == 0 || $item->checked_out == $user->get('id')))
+      if(isset($item->checked_out) && !($item->checked_out == 0 || $item->checked_out == $user->id))
       {
         // You are not allowed to resume the migration, since it is checked out by another user
         $this->setMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_CHECKED_OUT_BY_ANOTHER_USER', $user->get('name')), 'error');

--- a/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
+++ b/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
@@ -13,7 +13,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 \defined('_JEXEC') or die;
 
 use \Joomla\CMS\Factory;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\Path;
 use \Joomla\CMS\Menu\AbstractMenu;
 use \Psr\Container\ContainerInterface;
 use \Joomla\CMS\Extension\MVCComponent;

--- a/administrator/com_joomgallery/src/Extension/MessageTrait.php
+++ b/administrator/com_joomgallery/src/Extension/MessageTrait.php
@@ -140,7 +140,7 @@ trait MessageTrait
    *
    * @since   4.0.0
   */
-  protected function addLogger(string $name = null)
+  protected function addLogger(?string $name = null)
   {
     if(!$this->log)
     {
@@ -166,7 +166,7 @@ trait MessageTrait
    *
    * @since   4.0.0
   */
-  public function setLogger(string $name = null)
+  public function setLogger(?string $name = null)
   {
     $this->addLogger($name);
     $this->logName = $name;
@@ -182,7 +182,7 @@ trait MessageTrait
    *
    * @since   4.0.0
   */
-  public function addLog(string $txt, $priority = 8, string $name = null)
+  public function addLog(string $txt, $priority = 8, ?string $name = null)
   {
     $this->addLogger($name);
 
@@ -218,7 +218,7 @@ trait MessageTrait
    *
    * @since   4.0.0
   */
-  public function setLog(string $txt, $priority = 8, string $name = null)
+  public function setLog(string $txt, $priority = 8, ?string $name = null)
   {
     return $this->addLog($txt, $priority, $name);
   }
@@ -643,7 +643,7 @@ trait MessageTrait
         break;
 
       default:
-        throw new Exception("Selected storage does not exist.");
+        throw new \Exception("Selected storage does not exist.");
         return false;
     }
   }
@@ -656,7 +656,7 @@ trait MessageTrait
 	 * @return  string   The selected session path
 	 *
 	 * @since   4.0.0 
-   * @throws  Exception
+   * @throws  \Exception
 	*/
   protected function selectMsgStoragePath($selection)
   {
@@ -677,7 +677,7 @@ trait MessageTrait
         break;
 
       default:
-        throw new Exception("Selected storage does not exist.");
+        throw new \Exception("Selected storage does not exist.");
         return false;
     }
   }

--- a/administrator/com_joomgallery/src/Field/ImgprocessorlistField.php
+++ b/administrator/com_joomgallery/src/Field/ImgprocessorlistField.php
@@ -123,7 +123,7 @@ class ImgProcessorListField extends ListField
       else
       {
         $this->component->addLog(Text::sprintf('COM_JOOMGALLERY_PLUGIN_ERROR_RETURN_VALUE', 'onJoomImgProcessorGetName',  'array',  'value, text, desc'), 'error', 'jerror');
-        throw new Exception(Text::sprintf('COM_JOOMGALLERY_PLUGIN_ERROR_RETURN_VALUE', 'onJoomImgProcessorGetName',  'array',  'value, text, desc'));
+        throw new \Exception(Text::sprintf('COM_JOOMGALLERY_PLUGIN_ERROR_RETURN_VALUE', 'onJoomImgProcessorGetName',  'array',  'value, text, desc'));
       }
     }
 

--- a/administrator/com_joomgallery/src/Field/JgdynamiclistField.php
+++ b/administrator/com_joomgallery/src/Field/JgdynamiclistField.php
@@ -13,7 +13,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Form\Form;
-use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Event\AbstractEvent;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\ConfigHelper;
 

--- a/administrator/com_joomgallery/src/Form/ConfigForm.php
+++ b/administrator/com_joomgallery/src/Form/ConfigForm.php
@@ -235,7 +235,6 @@ class ConfigForm extends Form
    * @return  ConfigForm  Form instance.
    *
    * @since   4.0.0
-   * @deprecated  5.0 Use the FormFactory service from the container
    * @throws  \InvalidArgumentException if no data provided.
    * @throws  \RuntimeException if the form could not be loaded.
    */

--- a/administrator/com_joomgallery/src/Helper/ConfigHelper.php
+++ b/administrator/com_joomgallery/src/Helper/ConfigHelper.php
@@ -17,7 +17,7 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Registry\Registry;
-use \Joomla\CMS\Filesystem\Folder;
+use \Joomla\Filesystem\Folder;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 
 /**
@@ -68,7 +68,7 @@ class ConfigHelper
       require JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION.'/includes/iptcarray.php';
       require JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION.'/includes/exifarray.php';
       
-      $lang = Factory::getLanguage();
+      $lang = Factory::getApplication()->getLanguage();
       $lang->load(_JOOM_OPTION.'.exif', JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION);
       $lang->load(_JOOM_OPTION.'.iptc', JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION);
 

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -18,7 +18,7 @@ use \Joomla\CMS\Router\Route;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Registry\Registry;
 use \Joomla\CMS\Access\Access;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\Path;
 use \Joomla\CMS\Http\HttpFactory;
 use \Joomla\CMS\Language\Multilanguage;
 use \Joomla\Database\DatabaseInterface;
@@ -1120,7 +1120,7 @@ class JoomHelper
       if(!$adapter)
       {
         // Plugin is not installed, not enabled or not correctly configured. Show warning message.
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         if(!$lang->getPaths($plugin_fullname))
         {

--- a/administrator/com_joomgallery/src/MVC/MVCFactory.php
+++ b/administrator/com_joomgallery/src/MVC/MVCFactory.php
@@ -57,7 +57,7 @@ class MVCFactory extends MVCFactoryBase
    *
    * @since   4.0.0
    */
-  public function loadIdentity(User $identity = null)
+  public function loadIdentity(?User $identity = null)
   {
     if(\is_null($identity))
     {

--- a/administrator/com_joomgallery/src/Model/CategoriesModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoriesModel.php
@@ -186,7 +186,7 @@ class CategoriesModel extends JoomListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -403,7 +403,7 @@ class CategoriesModel extends JoomListModel
 	 */
   protected function categoriesFilterQuery(&$query, $categoryId, $level=false, $exclude=false)
   {
-    $db = $this->getDbo();
+    $db = $this->getDatabase();
 
     $categoryId = ArrayHelper::toInteger($categoryId);
     $categoryTable = $this->getMVCFactory()->createTable('Category', 'administrator');

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -765,18 +765,16 @@ class CategoryModel extends JoomAdminModel
 	 */
 	public function duplicate(&$pks)
 	{
-		$app  = Factory::getApplication();
-		$user = Factory::getContainer()->get(UserFactoryInterface::class);
-    $task = $app->input->get('task');
+    $task = $this->app->input->get('task');
 
 		// Access checks.
-		if(!$user->authorise('core.create', _JOOM_OPTION))
+		if(!$this->user->authorise('core.create', _JOOM_OPTION))
 		{
 			throw new \Exception(Text::_('JERROR_CORE_CREATE_NOT_PERMITTED'));
 		}
 
     // Set task to be save2copy
-    $app->input->set('task', 'save2copy');
+    $this->app->input->set('task', 'save2copy');
 
 		$table = $this->getTable();
 
@@ -807,7 +805,7 @@ class CategoryModel extends JoomAdminModel
         $data = (array) $table->getFieldsValues();
 
         // Set the id of the origin category
-        $app->input->set('origin_id', $pk);
+        $this->app->input->set('origin_id', $pk);
 
         // Save the copy
         $this->save($data);
@@ -815,11 +813,11 @@ class CategoryModel extends JoomAdminModel
       else
       {
         throw new \Exception($table->getError());
-      }			
+      }
 		}
 
     // Reset official task
-    $app->input->set('task', $task);
+    $this->app->input->set('task', $task);
 
 		// Clean cache
 		$this->cleanCache();

--- a/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -17,6 +17,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\Utilities\ArrayHelper;
 use \Joomla\CMS\Plugin\PluginHelper;
 use \Joomla\CMS\Language\Multilanguage;
+use \Joomla\CMS\User\UserFactoryInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 
 /**
@@ -765,7 +766,7 @@ class CategoryModel extends JoomAdminModel
 	public function duplicate(&$pks)
 	{
 		$app  = Factory::getApplication();
-		$user = Factory::getUser();
+		$user = Factory::getContainer()->get(UserFactoryInterface::class);
     $task = $app->input->get('task');
 
 		// Access checks.
@@ -834,14 +835,14 @@ class CategoryModel extends JoomAdminModel
 	 *
 	 * @return  boolean  True if successful.
 	 *
-	 * @throws  Exception
+	 * @throws  \Exception
 	 */
   public function fixChildrenPath($table, $old_table)
   {
     if(\is_null($table) || empty($table->id))
     {
       $this->component->addLog('To fix child category paths, table has to be loaded.', 'error', 'jerror');
-      throw new Exception('To fix child category paths, table has to be loaded.');
+      throw new \Exception('To fix child category paths, table has to be loaded.');
     }
 
     // Get a list of children ids

--- a/administrator/com_joomgallery/src/Model/ConfigModel.php
+++ b/administrator/com_joomgallery/src/Model/ConfigModel.php
@@ -784,7 +784,8 @@ class ConfigModel extends JoomAdminModel
 		}
 
 		// Check file extension
-		if(strtolower(File::getExt($file['name'])) != 'json')
+		$filesystem = JoomHelper::getService('Filesystem');
+		if(strtolower($filesystem->getExt($file['name'])) != 'json')
 		{
 			// Invalid file extension
 			$this->setError(Text::sprintf('COM_JOOMGALLERY_ERROR_INVALID_FILE_EXTENSION', 'json', $file['name']), 'error');

--- a/administrator/com_joomgallery/src/Model/ConfigModel.php
+++ b/administrator/com_joomgallery/src/Model/ConfigModel.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File;
+use \Joomla\Filesystem\File;
 use \Joomla\CMS\Plugin\PluginHelper;
 use \Joomla\CMS\Form\FormFactoryInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Form\FormFactory;
@@ -636,7 +636,7 @@ class ConfigModel extends JoomAdminModel
 	public function resetData($data)
 	{
 		// Load config form
-		$xmlfile = JPATH_COMPONENT_ADMINISTRATOR . '/forms/config.xml';
+		$xmlfile = _JOOM_PATH_ADMIN . '/forms/config.xml';
 		$cform = new Form('configForm');
 		$cform->loadFile($xmlfile);
 
@@ -655,7 +655,7 @@ class ConfigModel extends JoomAdminModel
 				else if($key == 'jg_staticprocessing')
 				{
 					// Load imageconvert subform
-					$xmlfile_subform = JPATH_COMPONENT_ADMINISTRATOR . '/forms/subform_imageconvert.xml';
+					$xmlfile_subform = _JOOM_PATH_ADMIN . '/forms/subform_imageconvert.xml';
 					$subform = new Form('imageconvertSubform');
 					$subform->loadFile($xmlfile_subform);
 
@@ -669,7 +669,7 @@ class ConfigModel extends JoomAdminModel
 								if($subformkey == 'jg_imgtypewtmsettings')
 								{
 									// Load imagewatermark subform
-									$xmlfile_wtmsubform = JPATH_COMPONENT_ADMINISTRATOR . '/forms/subform_imagewatermark.xml';
+									$xmlfile_wtmsubform = _JOOM_PATH_ADMIN . '/forms/subform_imagewatermark.xml';
 									$wtm_subform = new Form('imagewatermarkSubform');
 									$wtm_subform->loadFile($xmlfile_wtmsubform);
 
@@ -752,7 +752,7 @@ class ConfigModel extends JoomAdminModel
 	public function getJSONfile($file, $fieldname)
 	{
 		// Get form field
-		$xml = JPATH_COMPONENT_ADMINISTRATOR . '/forms/config.xml';
+		$xml = _JOOM_PATH_ADMIN . '/forms/config.xml';
 		$form = new Form('configForm');
 		$form->loadFile($xml);
 		$field = $form->getField($fieldname);

--- a/administrator/com_joomgallery/src/Model/ConfigsModel.php
+++ b/administrator/com_joomgallery/src/Model/ConfigsModel.php
@@ -12,7 +12,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 // No direct access.
 defined('_JEXEC') or die;
 
-use \Joomla\CMS\Factory;
+use \Joomla\Database\ParameterType;
 
 /**
  * Methods supporting a list of Configs records.
@@ -134,7 +134,7 @@ class ConfigsModel extends JoomListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -222,7 +222,7 @@ class ConfigsModel extends JoomListModel
 				{
 					if(!empty($value))
 					{
-						$db = Factory::getDbo();
+						$db = $this->getDatabase();
 						$query = "SELECT id, title FROM #__usergroups HAVING id LIKE '" . $value . "'";
 						$db->setQuery($query);
 						$results = $db->loadObject();

--- a/administrator/com_joomgallery/src/Model/ControlModel.php
+++ b/administrator/com_joomgallery/src/Model/ControlModel.php
@@ -53,7 +53,7 @@ class ControlModel extends BaseDatabaseModel
   {
     $statisticdata = array();
 
-    $db = Factory::getContainer()->get(DatabaseInterface::class);
+    $db = $this->getDatabase();
 
     $query = $db->getQuery(true)
       ->select($db->quoteName('id'))
@@ -114,7 +114,7 @@ class ControlModel extends BaseDatabaseModel
   {
     $galleryinfodata = array();
 
-    $db = Factory::getContainer()->get(DatabaseInterface::class);
+    $db = $this->getDatabase();
 
     $query = $db->getQuery(true)
                 ->select($db->quoteName('manifest_cache'))
@@ -222,7 +222,7 @@ class ControlModel extends BaseDatabaseModel
   {
     $InstalledExtensionsData = array();
 
-    $db = Factory::getContainer()->get(DatabaseInterface::class);
+    $db = $this->getDatabase();
 
     $query = $db->getQuery(true)
                 ->select($db->quoteName(array('extension_id', 'enabled', 'manifest_cache')))

--- a/administrator/com_joomgallery/src/Model/ControlModel.php
+++ b/administrator/com_joomgallery/src/Model/ControlModel.php
@@ -198,7 +198,10 @@ class ControlModel extends BaseDatabaseModel
       try
       {
         $info_extension    = $this->getBestUpdate(JoomHelper::fetchXML($url));
-        $extensions[$name] = \json_decode(\json_encode($info_extension), true);
+        if($info_extension)
+        {
+          $extensions[$name] = \json_decode(\json_encode($info_extension), true);
+        }        
       }
       catch (\Exception $e)
       {

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -250,11 +250,8 @@ class ImageModel extends JoomAdminModel
 	 */
 	public function duplicate(&$pks)
 	{
-		$app  = Factory::getApplication();
-		$user = Factory::getContainer()->get(UserFactoryInterface::class);
-
 		// Access checks.
-		if(!$user->authorise('core.create', _JOOM_OPTION))
+		if(!$this->user->authorise('core.create', _JOOM_OPTION))
 		{
 			throw new \Exception(Text::_('JERROR_CORE_CREATE_NOT_PERMITTED'));
 		}
@@ -315,7 +312,7 @@ class ImageModel extends JoomAdminModel
 				}
 
 				// Trigger the before save event.
-				$result = $app->triggerEvent($this->event_before_save, array($context, &$table, true, $table));
+				$result = $this->app->triggerEvent($this->event_before_save, array($context, &$table, true, $table));
 
 				if(in_array(false, $result, true) || !$table->store())
 				{
@@ -323,7 +320,7 @@ class ImageModel extends JoomAdminModel
 				}
 
 				// Trigger the after save event.
-				$app->triggerEvent($this->event_after_save, array($context, &$table, true));
+				$this->app->triggerEvent($this->event_after_save, array($context, &$table, true));
 			}
 			else
 			{
@@ -1220,6 +1217,6 @@ class ImageModel extends JoomAdminModel
    */
   protected function canRecreate($record)
   {
-    return Factory::getContainer()->get(UserFactoryInterface::class)->authorise('core.edit', $this->typeAlias);
+		return $this->getAcl()->checkACL('core.edit', $this->typeAlias);
   }
 }

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -16,8 +16,10 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Utilities\ArrayHelper;
+use \Joomla\Database\ParameterType;
 use \Joomla\CMS\Plugin\PluginHelper;
 use \Joomla\CMS\Language\Multilanguage;
+use \Joomla\CMS\User\UserFactoryInterface;
 use \Joomla\CMS\Form\FormFactoryInterface;
 use \Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
@@ -66,7 +68,7 @@ class ImageModel extends JoomAdminModel
    * @since   4.0.0
    * @throws  \Exception
    */
-  public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+  public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
   {
     parent::__construct($config, $factory, $formFactory);
 
@@ -249,7 +251,7 @@ class ImageModel extends JoomAdminModel
 	public function duplicate(&$pks)
 	{
 		$app  = Factory::getApplication();
-		$user = Factory::getUser();
+		$user = Factory::getContainer()->get(UserFactoryInterface::class);
 
 		// Access checks.
 		if(!$user->authorise('core.create', _JOOM_OPTION))
@@ -772,7 +774,7 @@ class ImageModel extends JoomAdminModel
 					// Multilanguage: if associated, delete the item in the _associations table
 					if($this->associationsContext && Associations::isEnabled())
 					{
-						$db = $this->getDbo();
+						$db = $this->getDatabase();
 						$query = $db->getQuery(true)
 							->select(
 								[
@@ -888,7 +890,7 @@ class ImageModel extends JoomAdminModel
 	 */
 	public function changeSate(&$pks, $type='publish', $value = 1)
 	{
-		$user    = Factory::getUser();
+		$user    = Factory::getContainer()->get(UserFactoryInterface::class);
 		$table   = $this->getTable();
 		$pks     = (array) $pks;
 		$context = $this->option . '.' . $this->name . '.' . $type;
@@ -1218,6 +1220,6 @@ class ImageModel extends JoomAdminModel
    */
   protected function canRecreate($record)
   {
-    return Factory::getUser()->authorise('core.edit', $this->typeAlias);
+    return Factory::getContainer()->get(UserFactoryInterface::class)->authorise('core.edit', $this->typeAlias);
   }
 }

--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -968,7 +968,7 @@ class ImageModel extends JoomAdminModel
 		}
 
 		// Attempt to change the state of the records.
-		if (!$table->changeState($type, $pks, $value, $user->get('id')))
+		if (!$table->changeState($type, $pks, $value, $user->id))
 		{
 			$this->setError($table->getError());
 

--- a/administrator/com_joomgallery/src/Model/ImagesModel.php
+++ b/administrator/com_joomgallery/src/Model/ImagesModel.php
@@ -181,7 +181,7 @@ class ImagesModel extends JoomListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/com_joomgallery/src/Model/ImagetypeModel.php
+++ b/administrator/com_joomgallery/src/Model/ImagetypeModel.php
@@ -87,9 +87,9 @@ class ImagetypeModel extends JoomAdminModel
 			}
 		}
 
-		// Convert to the CMSObject before adding other data.
-		$properties = $table->getProperties(1);
-		$item = ArrayHelper::toObject($properties, CMSObject::class);
+		// Convert to \stdClass before adding other data
+		$properties = get_object_vars($table);
+		$item       = ArrayHelper::toObject($properties);
 
     if(property_exists($item, 'params')) 
 		{

--- a/administrator/com_joomgallery/src/Model/ImagetypesModel.php
+++ b/administrator/com_joomgallery/src/Model/ImagetypesModel.php
@@ -53,7 +53,7 @@ class ImagetypesModel extends JoomListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -295,7 +295,7 @@ abstract class JoomAdminModel extends AdminModel
       $checkedOutField = $table->getColumnAlias('checked_out');
 
       // Check if this is the user having previously checked out the row.
-      if( $table->$checkedOutField > 0 && $table->$checkedOutField != $user->get('id') &&
+      if( $table->$checkedOutField > 0 && $table->$checkedOutField != $user->id &&
           !$user->authorise('core.manage', 'com_checkin')
         )
       {

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -273,8 +273,6 @@ abstract class JoomAdminModel extends AdminModel
     // Only attempt to check the row in if it exists.
     if($pk)
     {
-      $user = $this->getCurrentUser();
-
       // Get an instance of the row to checkin.
       $table = $this->getTable();
 
@@ -295,8 +293,8 @@ abstract class JoomAdminModel extends AdminModel
       $checkedOutField = $table->getColumnAlias('checked_out');
 
       // Check if this is the user having previously checked out the row.
-      if( $table->$checkedOutField > 0 && $table->$checkedOutField != $user->id &&
-          !$user->authorise('core.manage', 'com_checkin')
+      if( $table->$checkedOutField > 0 && $table->$checkedOutField != $this->user->id &&
+          !$this->user->authorise('core.manage', 'com_checkin')
         )
       {
         $this->component->setError(Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'));

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -546,7 +546,7 @@ abstract class JoomAdminModel extends AdminModel
     }
 
     // Get associationskey for edited item
-    $db    = $this->getDbo();
+    $db    = $this->getDatabase();
     $id    = (int) $table->$key;
     $query = $db->getQuery(true)
       ->select($db->quoteName('key'))
@@ -720,4 +720,24 @@ abstract class JoomAdminModel extends AdminModel
 
     return $table;
   }
+
+  /**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $property  The name of the property.
+	 * @param   mixed   $default   The default value.
+	 *
+	 * @return  mixed    The value of the property.
+	 *
+	 * @since   4.1.0
+	 */
+	public function get($property, $default = null)
+	{
+		if(isset($this->$property))
+		{
+			return $this->$property;
+		}
+
+		return $default;
+	}
 }

--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -18,8 +18,8 @@ use \Joomla\CMS\Form\Form;
 use \Joomla\CMS\Event\Model;
 use \Joomla\CMS\Language\Text;
 use \Joomla\Registry\Registry;
-use \Joomla\CMS\Filesystem\Path;
-use \Joomla\CMS\Filesystem\Folder;
+use \Joomla\Filesystem\Path;
+use \Joomla\Filesystem\Folder;
 use \Joomla\Database\DatabaseFactory;
 use \Joomla\CMS\Language\Multilanguage;
 use \Joomla\CMS\Form\FormFactoryInterface;
@@ -118,7 +118,7 @@ class MigrationModel extends JoomAdminModel
     if(!$params || empty($params))
     {
       // Load params from db if there are migrateables in database
-      $db    = $this->getDbo();
+      $db    = $this->getDatabase();
       $query = $db->getQuery(true);
 
       // Select the required fields from the table.
@@ -426,7 +426,7 @@ class MigrationModel extends JoomAdminModel
     // Get available types from db
     try
     {
-      $db    = $this->getDbo();
+      $db    = $this->getDatabase();
       $query = $this->getListQuery();
 
       if(\is_string($query))
@@ -574,7 +574,7 @@ class MigrationModel extends JoomAdminModel
     // Create a new query object.
     try
     {
-      $db    = $this->getDbo();
+      $db    = $this->getDatabase();
       $query = $db->getQuery(true);
 
       // Select the required fields from the table.
@@ -1236,7 +1236,7 @@ class MigrationModel extends JoomAdminModel
     }
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
     // Select the required fields from the table.

--- a/administrator/com_joomgallery/src/Model/TagModel.php
+++ b/administrator/com_joomgallery/src/Model/TagModel.php
@@ -68,7 +68,7 @@ class TagModel extends JoomAdminModel
 	 */
   protected function getItemID($string)
   {
-    $db = Factory::getDbo();
+    $db = $this->getDatabase();
     $query = $db->getQuery(true);
 
     $query->select($db->quoteName('id'));
@@ -158,7 +158,7 @@ class TagModel extends JoomAdminModel
 	 *
 	 * @return  boolean  True if successful.
 	 *
-	 * @throws  Exception
+	 * @throws  \Exception
 	 */
 	public function duplicate(&$pks)
 	{
@@ -226,7 +226,7 @@ class TagModel extends JoomAdminModel
    */
   public function addMapping($tag_id, $img_id)
   {
-    $db = Factory::getDbo();
+    $db = $this->getDatabase();
 
     $mapping = new \stdClass();
     $mapping->imgid = (int) $img_id;
@@ -262,7 +262,7 @@ class TagModel extends JoomAdminModel
     $tag_id = (int) $tag_id;
     $img_id = (int) $img_id;
 
-    $db = Factory::getDbo();
+    $db = $this->getDatabase();
     $query = $db->getQuery(true);
 
     $conditions = array($db->quoteName('tagid') . ' = ' . $db->quote($tag_id));

--- a/administrator/com_joomgallery/src/Model/TagsModel.php
+++ b/administrator/com_joomgallery/src/Model/TagsModel.php
@@ -147,7 +147,7 @@ class TagsModel extends JoomListModel
 	protected function getListQuery()
 	{
 		// Create a new query object. 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -282,7 +282,7 @@ class TagsModel extends JoomListModel
 	 */
 	public function searchItems($filters = array())
 	{
-    $db = Factory::getDbo();
+    $db = $this->getDatabase();
     $query = $db->getQuery(true)
             ->select([
                         $db->quoteName('a.id', 'value'),
@@ -364,7 +364,7 @@ class TagsModel extends JoomListModel
 	protected function getMappedListQuery($img_id)
 	{
     // Create a new query object. 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
     // Select the required fields from the table.

--- a/administrator/com_joomgallery/src/Router/RouterFactory.php
+++ b/administrator/com_joomgallery/src/Router/RouterFactory.php
@@ -63,7 +63,7 @@ class RouterFactory extends RouterFactoryBase implements RouterFactoryInterface
      *
      * @since   4.0.0
      */
-    public function __construct($namespace, CategoryFactoryInterface $categoryFactory = null, DatabaseInterface $db = null)
+    public function __construct($namespace, ?CategoryFactoryInterface $categoryFactory = null, ?DatabaseInterface $db = null)
     {
         $this->namespace       = $namespace;
         $this->categoryFactory = $categoryFactory;

--- a/administrator/com_joomgallery/src/Service/Access/Access.php
+++ b/administrator/com_joomgallery/src/Service/Access/Access.php
@@ -135,7 +135,7 @@ class Access implements AccessInterface
     $this->user = $this->component->getMVCFactory()->getIdentity();
 
     // Set acl map for components with advanced rules
-    $mapPath = JPATH_ADMINISTRATOR.'/components/'.$this->option.'/includes/rules.php';
+    $mapPath = _JOOM_PATH_ADMIN.'/includes/rules.php';
     if(\file_exists($mapPath))
     {
       require $mapPath;
@@ -234,7 +234,7 @@ class Access implements AccessInterface
 
     // More preparations
     $acl_rule_array = \explode('.', $acl_rule);
-    $appuser = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($this->user->get('id'));
+    $appuser = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($this->user->id);
 
     // Special case: super user
     if($appuser->get('isRoot') === true)
@@ -274,7 +274,7 @@ class Access implements AccessInterface
         // }
 
         // Only do the check, if it the pk is known
-        $this->allowed['own'] = AccessOwn::checkOwn($this->user->get('id'), $acl_rule, $asset, true, $own_pk);
+        $this->allowed['own'] = AccessOwn::checkOwn($this->user->id, $acl_rule, $asset, true, $own_pk);
       }
 
       // 3. Permission check if adding assets with media items (uploads)
@@ -288,11 +288,11 @@ class Access implements AccessInterface
 
         // Check for the category in general
         $this->tocheck['upload']     = true;
-        $this->allowed['upload']     = AccessBase::check($this->user->get('id'), $parent_action, $parent_asset);
+        $this->allowed['upload']     = AccessBase::check($this->user->id, $parent_action, $parent_asset);
 
         // Check also against parent ownership
         $this->tocheck['upload-own'] = true;
-        $this->allowed['upload-own'] = AccessOwn::checkOwn($this->user->get('id'), $parent_action.'.'.$this->aclMap[$action]['own'], $parent_asset, true, $parent_pk);
+        $this->allowed['upload-own'] = AccessOwn::checkOwn($this->user->id, $parent_action.'.'.$this->aclMap[$action]['own'], $parent_asset, true, $parent_pk);
       }
     }
     else
@@ -301,7 +301,7 @@ class Access implements AccessInterface
       if(!empty($this->aclMap) && $this->aclMap[$action]['own'] !== false && \in_array('.'.$asset_type, $this->aclMap[$action]['own-assets']))
       {
         $this->tocheck['own'] = true;
-        $this->allowed['own'] = AccessBase::check($this->user->get('id'), $acl_rule, $asset);
+        $this->allowed['own'] = AccessBase::check($this->user->id, $acl_rule, $asset);
       }
     }
 

--- a/administrator/com_joomgallery/src/Service/Access/Base/AccessOwn.php
+++ b/administrator/com_joomgallery/src/Service/Access/Base/AccessOwn.php
@@ -14,6 +14,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Access\Base;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Access\Access;
+use \Joomla\Database\DatabaseInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 
 /**
@@ -204,7 +205,7 @@ class AccessOwn extends Access
     if(empty(self::$viewLevelsList))
     {
       // Get a database object.
-      $db = Factory::getDbo();
+      $db = Factory::getContainer()->get(DatabaseInterface::class);
 
       // Build the base query.
       $query = $db->getQuery(true)

--- a/administrator/com_joomgallery/src/Service/Config/Config.php
+++ b/administrator/com_joomgallery/src/Service/Config/Config.php
@@ -465,7 +465,7 @@ abstract class Config extends \stdClass implements ConfigInterface
     }
 
     $userGroups  = \array_values($user->get('groups'));
-    $configGroup = $this->getUserSetting($user->get('id'));
+    $configGroup = $this->getUserSetting($user->id);
     
     if(\in_array($configGroup, $userGroups))
     {

--- a/administrator/com_joomgallery/src/Service/Config/Config.php
+++ b/administrator/com_joomgallery/src/Service/Config/Config.php
@@ -385,7 +385,16 @@ abstract class Config extends \stdClass implements ConfigInterface
     $id   = intval($id);
     $item = $model->getItem($id);
 
-    return $item->getProperties();
+    if(\method_exists($item, 'getProperties'))
+    {
+      $properties = $item->getProperties();
+    }
+    else
+    {
+      $properties = \get_object_vars($item);
+    }
+
+    return $properties;
   }
 
   /**

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -12,7 +12,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\FileManager;
 \defined('_JEXEC') or die;
 
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\Path;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\FileManager\FileManagerInterface;

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManagerServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManagerServiceInterface.php
@@ -19,15 +19,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\FileManager;
 interface FileManagerServiceInterface
 {
   /**
-	 * Storage for the file manager class.
-	 *
-	 * @var FileManagerInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $fileManager;
-
-  /**
 	 * Creates the file manager helper class
    *
    * @param   int          $catid       Id of the category for which the filesystem is chosen

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -17,8 +17,8 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Object\CMSObject;
 use \Joomla\CMS\Plugin\PluginHelper;
 use \Joomla\CMS\Filter\OutputFilter;
-use \Joomla\CMS\Filesystem\File as JFile;
-use \Joomla\CMS\Filesystem\Path as JPath;
+use \Joomla\Filesystem\File as JFile;
+use \Joomla\Filesystem\Path as JPath;
 
 use \Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
 use \Joomla\Component\Media\Administrator\Event\FetchMediaItemEvent;
@@ -102,7 +102,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
     }
 
     // Load language of com_media
-    Factory::getLanguage()->load('com_media', JPATH_ADMINISTRATOR);
+    Factory::getApplication()->getLanguage()->load('com_media', JPATH_ADMINISTRATOR);
   }
 
   /**
@@ -148,7 +148,7 @@ class Filesystem implements AdapterInterface, FilesystemInterface
       $filename = $file;
     }
 
-    if(Factory::getConfig()->get('unicodeslugs') == 1)
+    if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
     {
       $filename = OutputFilter::stringURLUnicodeSlug(trim($filename));
     }

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -261,7 +261,16 @@ class Filesystem implements AdapterInterface, FilesystemInterface
    */
   public function getExt(string $file): string
   {
-    $ext = JFile::getExt($file);
+    try
+    {
+      // Joomla 5+
+      $ext = JFile::getExt($file);
+    }
+    catch(\Throwable $th)
+    {
+      // Joomla 4-
+      $ext = \Joomla\CMS\Filesystem\File::getExt($file);
+    }    
 
     // Check if it is a valid extension
     $valid_rex = !\boolval(\preg_match('/[^a-zA-Z]/', $ext));  // File extension has to be only letters
@@ -582,7 +591,16 @@ class Filesystem implements AdapterInterface, FilesystemInterface
     $object->name      = $name;
     $object->path      = $path;
     $object->data      = $data;
-    $object->extension = strtolower(JFile::getExt($name));
+    try
+    {
+      // Joomla 5+
+      $object->extension = strtolower(JFile::getExt($name));
+    }
+    catch(\Throwable $th)
+    {
+      // Joomla 4-
+      $object->extension = strtolower(\Joomla\CMS\Filesystem\File::getExt($name));
+    }    
 
     PluginHelper::importPlugin('content');
 
@@ -634,7 +652,16 @@ class Filesystem implements AdapterInterface, FilesystemInterface
     $object->name      = $name;
     $object->path      = $path;
     $object->data      = $data;
-    $object->extension = strtolower(JFile::getExt($name));
+    try
+    {
+      // Joomla 5+
+      $object->extension = strtolower(JFile::getExt($name));
+    }
+    catch(\Throwable $th)
+    {
+      // Joomla 4-
+      $object->extension = strtolower(\Joomla\CMS\Filesystem\File::getExt($name));
+    }
 
     PluginHelper::importPlugin('content');
 

--- a/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceInterface.php
@@ -19,15 +19,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem;
 interface FilesystemServiceInterface
 {
   /**
-	 * Storage for the filesystem helper class.
-	 *
-	 * @var FilesystemInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $filesystem;
-
-  /**
 	 * Creates the filesystem helper class
    *
    * @param   string  $filesystem  Name of the filesystem adapter to be used

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -12,8 +12,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 // No direct access
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Filesystem\File;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\File;
+use \Joomla\Filesystem\Path;
 use \Joomla\CMS\Language\Text;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\GifFrameExtractor;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\GifCreator;

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -287,7 +287,8 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     }
 
     // Define image type to write
-    $type = \strtoupper(File::getExt($file));
+    $filesystem = JoomHelper::getService('Filesystem');
+    $type = \strtoupper($filesystem->getExt($file));
     if(!empty($type))
     {
       if(\in_array($type, $this->supported_types))

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -337,7 +337,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
     }
     else
     {
-      if(File::exists($file))
+      if(\is_file(Path::clean($file)))
       {
         $bak_file = $file.'bak';
         $success  = File::copy($file, $bak_file);
@@ -377,7 +377,7 @@ class GDtools extends BaseIMGtools implements IMGtoolsInterface
       }
       else
       {
-        if(File::exists($file))
+        if(\is_file(Path::clean($file)))
         {
           $bak_file = $file.'bak';
           $success  = File::copy($file, $bak_file);

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -10,10 +10,10 @@
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
 // No direct access
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File;
+use \Joomla\Filesystem\File;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\GifFrameExtractor;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\IMGtoolsInterface;

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -12,8 +12,9 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 // No direct access
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Language\Text;
 use \Joomla\Filesystem\File;
+use \Joomla\Filesystem\Path;
+use \Joomla\CMS\Language\Text;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\GifFrameExtractor;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\IMGtoolsInterface;
@@ -534,7 +535,7 @@ abstract class IMGtools implements IMGtoolsInterface
   protected function checkValidImage($img)
   {
     // Path must point to an existing file
-    if(!(File::exists($img)))
+    if(!(\is_file(Path::clean($img))))
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING'));
       $this->component->addLog(Text::_('COM_JOOMGALLERY_ERROR_FILE_NOT_EXISTING'), 'error', 'jerror');
@@ -975,7 +976,7 @@ abstract class IMGtools implements IMGtoolsInterface
     // Restore src from backup file or delete corrupt dst file
     if($src_file == $dst_file && $src_file != '')
     {
-      if(File::exists($src_file.'bak'))
+      if(\is_file(Path::clean($src_file.'bak')))
       {
         File::copy($src_file.'bak',$src_file);
         File::delete($src_file.'bak');
@@ -983,14 +984,14 @@ abstract class IMGtools implements IMGtoolsInterface
     }
     elseif($dst_file != '')
     {
-      if(File::exists($dst_file.'bak'))
+      if(\is_file(Path::clean($dst_file.'bak')))
       {
         File::copy($dst_file.'bak',$dst_file);
         File::delete($dst_file.'bak');
       }
       else
       {
-        if(File::exists($dst_file))
+        if(\is_file(Path::clean($dst_file)))
         {
           File::delete($dst_file);
         }

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsInterface.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * Interface for the IMGtools class

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * The IMGtools service
@@ -18,15 +18,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 */
 interface IMGtoolsServiceInterface
 {
-  /**
-	 * Storage for the IMGtools class.
-	 *
-	 * @var IMGtoolsInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $IMGtools;
-
   /**
 	 * Creates the IMGtools class
    *

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtoolsServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\IMtools;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\GDtools;

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -386,7 +386,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
       // Perform watermarking
       $wtm_files = $this->execWatermarking($file, $file);
 
-      if(!File::exists($wtm_files['dst_file']))
+      if(!\is_file(Path::clean($wtm_files['dst_file'])))
       {
         $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_ERROR_WATERMARKING'));
         $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_ERROR_WATERMARKING'), 'error', 'jerror');
@@ -402,13 +402,13 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_MANIPULATION_SUCCESSFUL'));
 
     // Delete watermarked temp file if existing
-    if($this->watermarking && File::exists($wtm_files['dst_file']) && \strpos($wtm_files['dst_file'], 'tmp_wtm_img') !== false)
+    if($this->watermarking && \is_file(Path::clean($wtm_files['dst_file'])) && \strpos($wtm_files['dst_file'], 'tmp_wtm_img') !== false)
     {
       File::delete($wtm_files['dst_file']);
     }
 
     // Delete resized watermark file
-    if($this->watermarking && File::exists($wtm_files['wtm_file']))
+    if($this->watermarking && \is_file(Path::clean($wtm_files['wtm_file'])))
     {
       File::delete($wtm_files['wtm_file']);
     }
@@ -933,7 +933,7 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
     }
 
     // Checks if watermark file is existent
-    if(!File::exists($wtm_file))
+    if(!\is_file(Path::clean($wtm_file)))
     {
       $this->component->addDebug(Text::_('COM_JOOMGALLERY_SERVICE_ERROR_WATERMARK_NOT_EXIST'));
       $this->component->addLog(Text::_('COM_JOOMGALLERY_SERVICE_ERROR_WATERMARK_NOT_EXIST'), 'error', 'jerror');

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -12,8 +12,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 // No direct access
 \defined('_JEXEC') or die;
 
-use \Joomla\CMS\Filesystem\File;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\File;
+use \Joomla\Filesystem\Path;
 use \Joomla\CMS\Language\Text;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\IMGtoolsInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools\IMGtools as BaseIMGtools;

--- a/administrator/com_joomgallery/src/Service/Messenger/MessengerServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/MessengerServiceInterface.php
@@ -19,15 +19,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 interface MessengerServiceInterface
 {
   /**
-	 * Storage for the messenger service class.
-	 *
-	 * @var MessengerInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $messenger;
-
-  /**
 	 * Creates the messenger service class
    * 
    * @param   string  $msgMethod   Name of the messager to be used

--- a/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
@@ -128,7 +128,7 @@ class PmMessenger extends Messenger implements MessengerInterface
     }
 
     // Check for locked inboxes would be better to have _cdf settings in the user_object or a filter in users model
-    $db = Factory::getDbo();
+    $db = Factory::getContainer()->get(DatabaseInterface::class);
     $query = $db->getQuery(true);
 
     $query->select($db->quoteName('user_id'))

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -239,7 +239,7 @@ abstract class Migration implements MigrationInterface
    *
    * @since   4.0.0
    */
-  public function getQueue(string $type, object $migrateable=null): array
+  public function getQueue(string $type, ?object $migrateable = null): array
   {
     if(\is_null($migrateable))
     {
@@ -1466,7 +1466,7 @@ abstract class Migration implements MigrationInterface
     // Get a list of used ids from destination database
     $destQuery = $db->getQuery(true);
     $destQuery->select($db->quoteName('id'))
-        ->from($db->quoteName($tablename));
+              ->from($db->quoteName($tablename));
     $destQuery_string = \trim($destQuery->__toString());
 
     if($this->params->get('same_db', 1))
@@ -1474,7 +1474,7 @@ abstract class Migration implements MigrationInterface
       // Get list of used ids from source database
       $srcQuery = $db->getQuery(true);
       $srcQuery->select($db->quoteName($migrateable->get('src_pk'), 'id'))
-          ->from($db->quoteName($migrateable->get('src_table')));
+               ->from($db->quoteName($migrateable->get('src_table')));
       $srcQuery_string = \trim($srcQuery->__toString());
 
       // Get a list of ids used in both source and destination
@@ -1492,7 +1492,7 @@ abstract class Migration implements MigrationInterface
       // Get list of used ids from the source database
       $query = $src_db->getQuery(true);
       $query->select($db->quoteName($migrateable->get('src_pk'), 'id'))
-          ->from($db->quoteName($migrateable->get('src_table')));
+            ->from($db->quoteName($migrateable->get('src_table')));
       $src_db->setQuery($query);
 
       // Load list from source database

--- a/administrator/com_joomgallery/src/Service/Migration/MigrationInterface.php
+++ b/administrator/com_joomgallery/src/Service/Migration/MigrationInterface.php
@@ -169,7 +169,7 @@ interface MigrationInterface
    *
    * @since   4.0.0
    */
-  public function getQueue(string $type, object $migrateable=null): array;
+  public function getQueue(string $type, ?object $migrateable = null): array;
 
   /**
    * Returns an associative array containing the record data from source.

--- a/administrator/com_joomgallery/src/Service/Migration/MigrationServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Migration/MigrationServiceInterface.php
@@ -19,15 +19,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 interface MigrationServiceInterface
 {
   /**
-	 * Storage for the migration service class.
-	 *
-	 * @var MigrationInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $migration;
-
-  /**
 	 * Creates the migration service class
    * 
    * @param   string  $script   Name of the migration script to be used

--- a/administrator/com_joomgallery/src/Service/Migration/MigrationServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Migration/MigrationServiceTrait.php
@@ -13,8 +13,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
 use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\Folder;
-use \Joomla\CMS\Filesystem\Path;
+use \Joomla\Filesystem\Folder;
+use \Joomla\Filesystem\Path;
 
 /**
 * Trait to implement MigrationServiceInterface

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -472,7 +472,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
    *
    * @since   4.0.0
    */
-  public function getQueue(string $type, object $migrateable=null): array
+  public function getQueue(string $type, ?object $migrateable = null): array
   {
     if(\is_null($migrateable))
     {
@@ -1273,7 +1273,7 @@ class Jg3ToJg4 extends Migration implements MigrationInterface
             foreach($titles as $id => $title)
             {
 
-              if(Factory::getConfig()->get('unicodeslugs') == 1)
+              if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
               {
                 $titles[$id] = OutputFilter::stringURLUnicodeSlug(trim($title));
               }

--- a/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceInterface.php
@@ -19,15 +19,6 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Refresher;
 interface RefresherServiceInterface
 {
   /**
-	 * Refresher for the refresher class.
-	 *
-	 * @var RefresherInterface
-	 *
-	 * @since  4.0.0
-	 */
-	private $refresher;
-
-  /**
 	 * Creates the refresher helper class
    * 
    * @param   array  $params   An array with optional parameters

--- a/administrator/com_joomgallery/src/Service/TusServer/Exception/FileNotFoundException.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/Exception/FileNotFoundException.php
@@ -17,7 +17,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer\Exce
  */
 class FileNotFoundException extends IOException
 {
-    public function __construct($message = null, $code = 0, \Exception $previous = null, $path = null)
+    public function __construct($message = null, $code = 0, ?\Exception $previous = null, $path = null)
     {
         if (null === $message) {
             if (null === $path) {

--- a/administrator/com_joomgallery/src/Service/TusServer/Exception/IOException.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/Exception/IOException.php
@@ -20,7 +20,7 @@ class IOException extends \RuntimeException implements IOExceptionInterface
 {
     private $path;
 
-    public function __construct($message, $code = 0, \Exception $previous = null, $path = null)
+    public function __construct($message, $code = 0, ?\Exception $previous = null, $path = null)
     {
         $this->path = $path;
 

--- a/administrator/com_joomgallery/src/Service/TusServer/FileToolsService.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/FileToolsService.php
@@ -10,7 +10,7 @@
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
 // No direct access
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\TusServer\Exception\FileNotFoundException;
 
@@ -72,7 +72,7 @@ class FileToolsService
             header('Content-Type: ' . $mime);
         }
 
-        if (strstr(filter_input(INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_SANITIZE_STRING), "MSIE") != false) {
+        if (strstr(filter_input(INPUT_SERVER, 'HTTP_USER_AGENT', FILTER_UNSAFE_RAW), "MSIE") != false) {
             header("Content-Disposition: ".$openMode."; filename=" . urlencode($fileName) . '; modification-date="' . date('r', $mtime) . '";');
         }
         else {

--- a/administrator/com_joomgallery/src/Service/TusServer/Server.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/Server.php
@@ -10,7 +10,7 @@
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
 // No direct access
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use \Joomla\CMS\Factory;
 use \Psr\Http\Message\ResponseInterface;
@@ -295,7 +295,7 @@ class Server implements ServerInterface
      *
      * @return  bool    True on success, false otherwise
      */
-    public function loadUpload(string $uuid=null): bool
+    public function loadUpload(?string $uuid = null): bool
     {
       $this->uuid = $uuid;
       $this->getUserUuid();

--- a/administrator/com_joomgallery/src/Service/TusServer/ServerInterface.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/ServerInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use Psr\Http\Message\ResponseInterface;
 
@@ -49,7 +49,7 @@ interface ServerInterface
    * 
    * @return  bool    True on success, false otherwise
    */
-  public function loadUpload(string $uuid=null): bool;
+  public function loadUpload(?string $uuid = null): bool;
 
   /**
    * Sets upload size limit

--- a/administrator/com_joomgallery/src/Service/TusServer/TusServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/TusServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\TusServer\ServerInterface;
 

--- a/administrator/com_joomgallery/src/Service/TusServer/TusServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/TusServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Uri\Uri;

--- a/administrator/com_joomgallery/src/Service/Uploader/HTMLUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/HTMLUploader.php
@@ -77,10 +77,10 @@ class HTMLUploader extends BaseUploader implements UploaderInterface
     }
 
     // Get number of uploaded images of the current user
-    $counter = $this->getImageNumber($user->get('id'));
+    $counter = $this->getImageNumber($user->id);
 
     // Check if user already exceeds its upload limit
-    if($this->app->isClient('site') && $counter > ($this->component->getConfig()->get('jg_maxuserimage') - 1) && $user->get('id'))
+    if($this->app->isClient('site') && $counter > ($this->component->getConfig()->get('jg_maxuserimage') - 1) && $user->id)
     {
       $timespan = $this->component->getConfig()->get('jg_maxuserimage_timespan');
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_UPLOAD_OUTPUT_MAY_ADD_MAX_OF', $this->component->getConfig()->get('jg_maxuserimage'), $timespan > 0 ? Text::plural('COM_JOOMGALLERY_UPLOAD_NEW_IMAGE_MAXCOUNT_TIMESPAN', $timespan) : ''));

--- a/administrator/com_joomgallery/src/Service/Uploader/TUSUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/TUSUploader.php
@@ -82,11 +82,11 @@ class TUSUploader extends BaseUploader implements UploaderInterface
     }
 
     // Get number of uploaded images of the current user
-    $counter = $this->getImageNumber($user->get('id'));
+    $counter = $this->getImageNumber($user->id);
     $is_site = $this->app->isClient('site');
 
     // Check if user already exceeds its upload limit
-    if($is_site && $counter > ($this->component->getConfig()->get('jg_maxuserimage') - 1) && $user->get('id'))
+    if($is_site && $counter > ($this->component->getConfig()->get('jg_maxuserimage') - 1) && $user->id)
     {
       $timespan = $this->component->getConfig()->get('jg_maxuserimage_timespan');
       $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_UPLOAD_OUTPUT_MAY_ADD_MAX_OF', $this->component->getConfig()->get('jg_maxuserimage'), $timespan > 0 ? Text::plural('COM_JOOMGALLERY_UPLOAD_NEW_IMAGE_MAXCOUNT_TIMESPAN', $timespan) : ''));

--- a/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
@@ -229,8 +229,11 @@ abstract class Uploader implements UploaderInterface
    */
   public function overrideData(&$data): bool
   {
+    // Create filesystem service
+    $this->component->createFilesystem();
+
     // Get image extension
-    $tag = strtolower(JFile::getExt($this->src_file));
+    $tag = $this->component->getFilesystem()->getExt($this->src_file);
 
     if(!($tag == 'jpg' || $tag == 'jpeg' || $tag == 'jpe' || $tag == 'jfif'))
     {

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -208,7 +208,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
 			}
 			else
 			{
-				if(Factory::getConfig()->get('unicodeslugs') == 1)
+				if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
 				{
 					$array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['title']));
 				}
@@ -220,7 +220,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
 		}
     else
     {
-      if(Factory::getConfig()->get('unicodeslugs') == 1)
+      if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
       {
         $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['alias']));
       }
@@ -472,7 +472,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
    */
   public function addRoot()
   {
-    $db = $this->getDbo();
+    $db = $this->getDatabase();
 
     $checkQuery = $db->getQuery(true);
     $checkQuery->select('*');
@@ -522,7 +522,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
       $name = $this->typeAlias . '.1';
 
       // Create asset for root category
-      $assetTable = new Asset($this->getDbo());
+      $assetTable = new Asset($this->getDatabase());
       $assetTable->loadByName($name);
 
       if($assetTable->getError())
@@ -629,7 +629,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     }
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
     // Select the required fields from the table.
@@ -751,7 +751,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     }
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
     // Select the required fields from the table.

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -35,6 +35,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
   use JoomTableTrait;
   use MultipleAssetsTableTrait;
   use MigrationTableTrait;
+  use LegacyDatabaseTrait;
   
   /**
    * Object property to hold the path of the new location reference node.

--- a/administrator/com_joomgallery/src/Table/CollectionTable.php
+++ b/administrator/com_joomgallery/src/Table/CollectionTable.php
@@ -29,6 +29,7 @@ class CollectionTable extends Table
   use JoomTableTrait;
   use AssetTableTrait;
   use MigrationTableTrait;
+  use LegacyDatabaseTrait;
 
   /**
    * List of images connected to this collection

--- a/administrator/com_joomgallery/src/Table/CollectionTable.php
+++ b/administrator/com_joomgallery/src/Table/CollectionTable.php
@@ -98,7 +98,7 @@ class CollectionTable extends Table
 			}
 			else
 			{
-				if(Factory::getConfig()->get('unicodeslugs') == 1)
+				if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
 				{
 					$array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['title']));
 				}
@@ -110,7 +110,7 @@ class CollectionTable extends Table
 		}
     else
     {
-      if(Factory::getConfig()->get('unicodeslugs') == 1)
+      if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
       {
         $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['alias']));
       }
@@ -285,7 +285,7 @@ class CollectionTable extends Table
     }
 
     // Load db driver
-    $db = $this->getDbo();
+    $db = $this->getDatabase();
 
     foreach($img_id as $key => $iid)
     {
@@ -342,7 +342,7 @@ class CollectionTable extends Table
     }
 
     // Load db driver
-    $db    = $this->getDbo();
+    $db    = $this->getDatabase();
     $query = $db->getQuery(true);
 
     // Create where conditions

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -32,7 +32,8 @@ class ImageTable extends Table implements VersionableTableInterface
 {
   use JoomTableTrait;
   use NoAssetTableTrait;
-	use MigrationTableTrait;
+  use MigrationTableTrait;
+  use LegacyDatabaseTrait;
 
 	/**
 	 * Constructor

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -63,7 +63,7 @@ class ImageTable extends Table implements VersionableTableInterface
 	protected function _getAssetParentId($table = null, $id = null)
 	{
 		// We will retrieve the parent-asset from the Asset-table
-		$assetTable = new Asset($this->getDbo());
+		$assetTable = new Asset($this->getDatabase());
 
 		if($this->catid)
 		{
@@ -179,7 +179,7 @@ class ImageTable extends Table implements VersionableTableInterface
 			}
 			else
 			{
-				if(Factory::getConfig()->get('unicodeslugs') == 1)
+				if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
 				{
 					$array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['title']));
 				}
@@ -191,7 +191,7 @@ class ImageTable extends Table implements VersionableTableInterface
 		}
     else
     {
-      if(Factory::getConfig()->get('unicodeslugs') == 1)
+      if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
       {
         $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['alias']));
       }
@@ -515,18 +515,19 @@ class ImageTable extends Table implements VersionableTableInterface
     }
 		$checkedOutField = $this->getColumnAlias('checked_out');
 
+		$db = $this->getDatabase();
 		foreach ($pks as $pk)
 		{
 			// Update the publishing state for rows with the given primary keys.
-			$query = $this->_db->getQuery(true)
+			$query = $db->getQuery(true)
 				->update($this->_tbl)
-				->set($this->_db->quoteName($stateField) . ' = ' . (int) $state);
+				->set($db->quoteName($stateField) . ' = ' . (int) $state);
 
 			// If publishing, set published date/time if not previously set
 			if ($state && $this->hasField('publish_up') && (int) $this->publish_up == 0)
 			{
-				$nowDate = $this->_db->quote(Factory::getDate()->toSql());
-				$query->set($this->_db->quoteName($this->getColumnAlias('publish_up')) . ' = ' . $nowDate);
+				$nowDate = $db->quote(Factory::getDate()->toSql());
+				$query->set($db->quoteName($this->getColumnAlias('publish_up')) . ' = ' . $nowDate);
 			}
 
 			// Determine if there is checkin support for the table.
@@ -534,9 +535,9 @@ class ImageTable extends Table implements VersionableTableInterface
 			{
 				$query->where(
 					'('
-						. $this->_db->quoteName($checkedOutField) . ' = 0'
-						. ' OR ' . $this->_db->quoteName($checkedOutField) . ' = ' . (int) $userId
-						. ' OR ' . $this->_db->quoteName($checkedOutField) . ' IS NULL'
+						. $db->quoteName($checkedOutField) . ' = 0'
+						. ' OR ' . $db->quoteName($checkedOutField) . ' = ' . (int) $userId
+						. ' OR ' . $db->quoteName($checkedOutField) . ' IS NULL'
 					. ')'
 				);
 				$checkin = true;
@@ -549,11 +550,11 @@ class ImageTable extends Table implements VersionableTableInterface
 			// Build the WHERE clause for the primary keys.
 			$this->appendPrimaryKeys($query, $pk);
 
-			$this->_db->setQuery($query);
+			$db->setQuery($query);
 
 			try
 			{
-				$this->_db->execute();
+				$db->execute();
 			}
 			catch (\RuntimeException $e)
 			{
@@ -564,7 +565,7 @@ class ImageTable extends Table implements VersionableTableInterface
 			}
 
 			// If checkin is supported and all rows were adjusted, check them in.
-			if ($checkin && (\count($pks) == $this->_db->getAffectedRows()))
+			if ($checkin && (\count($pks) == $db->getAffectedRows()))
 			{
 				$this->checkIn($pk);
 			}

--- a/administrator/com_joomgallery/src/Table/JoomTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/JoomTableTrait.php
@@ -167,7 +167,7 @@ trait JoomTableTrait
         }
         else
         {
-          if(Factory::getConfig()->get('unicodeslugs') == 1)
+          if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
           {
             $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['title']));
           }
@@ -179,7 +179,7 @@ trait JoomTableTrait
       }
       else
       {
-        if(Factory::getConfig()->get('unicodeslugs') == 1)
+        if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
         {
           $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['alias']));
         }
@@ -235,9 +235,9 @@ trait JoomTableTrait
 	 */
   public function getFieldsValues($exclude = array())
   {
-    // Convert to the CMSObject before adding other data.
+    // Convert to \stdClass before adding other data
 		$properties = $this->getProperties(1);
-		$item = ArrayHelper::toObject($properties, CMSObject::class);
+		$item       = ArrayHelper::toObject($properties);
 
 		if(\property_exists($item, 'params'))
 		{
@@ -465,14 +465,14 @@ trait JoomTableTrait
   protected function loadForm($form)
   {
     // Get xml file path
-    if(\file_exists(JPATH_COMPONENT_ADMINISTRATOR . '/forms/'.$form.'.xml'))
+    if(\file_exists(_JOOM_PATH_ADMIN . '/forms/'.$form.'.xml'))
     {
-      $xml_file  = JPATH_COMPONENT_ADMINISTRATOR . '/forms/'.$form.'.xml';
+      $xml_file  = _JOOM_PATH_ADMIN . '/forms/'.$form.'.xml';
       $form_name = $form;
     }
-    elseif(\file_exists(JPATH_COMPONENT_ADMINISTRATOR . '/forms/'.$form))
+    elseif(\file_exists(_JOOM_PATH_ADMIN . '/forms/'.$form))
     {
-      $xml_file  = JPATH_COMPONENT_ADMINISTRATOR . '/forms/'.$form;
+      $xml_file  = _JOOM_PATH_ADMIN . '/forms/'.$form;
       $form_name = \str_replace('.xml', '', $form);
     }
 

--- a/administrator/com_joomgallery/src/Table/LegacyDatabaseTrait.php
+++ b/administrator/com_joomgallery/src/Table/LegacyDatabaseTrait.php
@@ -1,0 +1,68 @@
+<?php
+/**
+******************************************************************************************
+**   @package    com_joomgallery                                                        **
+**   @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>                 **
+**   @copyright  2008 - 2025  JoomGallery::ProjectTeam                                  **
+**   @license    GNU General Public License version 3 or later                          **
+*****************************************************************************************/
+
+namespace Joomgallery\Component\Joomgallery\Administrator\Table;
+
+\defined('_JEXEC') or die;
+
+use \Joomla\Database\DatabaseInterface;
+
+/**
+* Trait to bridge the transition between getDbo and getDatabse
+*
+* @since  4.1.0
+*/
+trait LegacyDatabaseTrait
+{
+  /**
+   * Get the database.
+   *
+   * @return  DatabaseInterface
+   *
+   * @throws  DatabaseNotFoundException May be thrown if the database has not been set.
+   * @throws  LogicException May be thrown if neighter getDatabase nor getDbo is available.
+   * @note    This method will be removed in 7.0 and DatabaseAwareTrait will be used instead.
+   */
+  protected function getDatabase(): DatabaseInterface
+  {
+    $parentClass = \get_parent_class($this);
+
+    if($parentClass && \method_exists($parentClass, 'getDatabase'))
+    {
+      $method = new \ReflectionMethod($parentClass, 'getDatabase');
+
+      if($method->isProtected() || $method->isPublic())
+      {
+        // Call parent::getDatabase() even if overridden by trait
+        return $method->invoke($this);
+      }
+    }
+
+    if(\method_exists($this, 'getDbo'))
+    {
+      return $this->getDbo();
+    }
+
+    throw new \LogicException('Neither getDatabase nor getDbo is available.');
+  }
+
+  /**
+   * Set the database.
+   *
+   * @param   DatabaseInterface  $db  The database.
+   *
+   * @return  void
+   * @note    This method will be removed in 7.0 and DatabaseAwareTrait will be used instead.
+   */
+  public function setDatabase(DatabaseInterface $db): void
+  {
+    $this->_db                        = $db;
+    $this->databaseAwareTraitDatabase = $db;
+  }
+}

--- a/administrator/com_joomgallery/src/Table/LegacyDatabaseTrait.php
+++ b/administrator/com_joomgallery/src/Table/LegacyDatabaseTrait.php
@@ -54,6 +54,7 @@ trait LegacyDatabaseTrait
       $currentClass = $parent;
     }
 
+    // If we havent found getDatabase(), we use getDbo()
     if(\method_exists($this, 'getDbo'))
     {
       return $this->getDbo();

--- a/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
+++ b/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
@@ -27,6 +27,7 @@ use \Joomgallery\Component\Joomgallery\Administrator\Table\Asset\MultipleAssetsT
 class MultipleAssetsTable extends Table
 {
   use MultipleAssetsTableTrait;
+  use LegacyDatabaseTrait;
 
   /**
    * The rules associated with this record.

--- a/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
+++ b/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
@@ -127,8 +127,7 @@ class MultipleAssetsTable extends Table
         $name     = $this->_getAssetName($key);
         $title    = $this->_getAssetTitle($key);
 
-        /** @var Asset $asset */
-        $asset = self::getInstance('Asset', 'JTable', ['dbo' => $this->getDbo()]);
+        $asset = new Asset($this->getDatabase(), $this->getDispatcher());
         $asset->loadByName($name);
 
         // Get asset id property name
@@ -175,11 +174,11 @@ class MultipleAssetsTable extends Table
                     // Update the asset_id field in this table.
                     $this->{$assetIdName} = (int) $asset->id;
 
-                    $query = $this->_db->getQuery(true)
-                        ->update($this->_db->quoteName($this->_tbl))
+                    $query = $this->getDatabase()->getQuery(true)
+                        ->update($this->getDatabase()->quoteName($this->_tbl))
                         ->set($assetIdName . ' = ' . (int) $this->{$assetIdName});
                     $this->appendPrimaryKeys($query);
-                    $this->_db->setQuery($query)->execute();
+                    $this->getDatabase()->setQuery($query)->execute();
                 }
             }
         }
@@ -231,8 +230,7 @@ class MultipleAssetsTable extends Table
           //Get the asset name
           $name  = $this->_getAssetName($itemtype);
 
-          /** @var Asset $asset */
-          $asset = Table::getInstance('Asset', 'JTable', ['dbo' => $this->getDbo()]);
+          $asset = new Asset($this->getDatabase(), $this->getDispatcher());
 
           if ($asset->loadByName($name)) {
             // Delete the node in assets table.

--- a/administrator/com_joomgallery/src/Table/TagTable.php
+++ b/administrator/com_joomgallery/src/Table/TagTable.php
@@ -30,6 +30,7 @@ class TagTable extends Table
 {
   use JoomTableTrait;
   use GlobalAssetTableTrait;
+  use LegacyDatabaseTrait;
 
   /**
    * List of images connected to this tag

--- a/administrator/com_joomgallery/src/Table/TagTable.php
+++ b/administrator/com_joomgallery/src/Table/TagTable.php
@@ -92,7 +92,7 @@ class TagTable extends Table
 			}
 			else
 			{
-				if(Factory::getConfig()->get('unicodeslugs') == 1)
+				if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
 				{
 					$array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['title']));
 				}
@@ -104,7 +104,7 @@ class TagTable extends Table
 		}
     else
     {
-      if(Factory::getConfig()->get('unicodeslugs') == 1)
+      if(Factory::getApplication()->getConfig()->get('unicodeslugs') == 1)
       {
         $array['alias'] = OutputFilter::stringURLUnicodeSlug(trim($array['alias']));
       }
@@ -251,7 +251,7 @@ class TagTable extends Table
     }
 
     // Load db driver
-    $db = $this->getDbo();
+    $db = $this->getDatabase();
 
     foreach($img_id as $key => $iid)
     {
@@ -300,7 +300,7 @@ class TagTable extends Table
     }
 
     // Load db driver
-    $db    = $this->getDbo();
+    $db    = $this->getDatabase();
     $query = $db->getQuery(true);
 
     // Create where conditions

--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends JoomGalleryView
     ToolbarHelper::title(Text::_('JCATEGORIES'), "folder-open");
 
     /** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
     $formPath = _JOOM_PATH_ADMIN . '/src/View/Categories';

--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
 use \Joomla\CMS\HTML\Helpers\Sidebar;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
@@ -42,16 +43,19 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    $this->state         = $this->get('State');
-    $this->items         = $this->get('Items');		
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+    /** @var CategoriesModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if(count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
     // Preprocess the list of items to find ordering divisions.
@@ -77,10 +81,11 @@ class HtmlView extends JoomGalleryView
   {
     ToolbarHelper::title(Text::_('JCATEGORIES'), "folder-open");
 
-    $toolbar = Toolbar::getInstance('toolbar');
+    /** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
-    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Categories';
+    $formPath = _JOOM_PATH_ADMIN . '/src/View/Categories';
 
     // Show button back to control panel
     $html = '<a href="index.php?option=com_joomgallery&amp;view=control" class="btn btn-primary"><span class="icon-arrow-left-4" title="'.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'"></span> '.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'</a>';

--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -80,7 +80,7 @@ class HtmlView extends JoomGalleryView
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
 		/** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -87,7 +87,7 @@ class HtmlView extends JoomGalleryView
 
 		if(isset($this->item->checked_out))
 		{
-			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->id);
 		}
 		else
 		{

--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
 /**
@@ -41,9 +42,12 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state = $this->get('State');
-		$this->item  = $this->get('Item');
-		$this->form  = $this->get('Form');
+		/** @var CategoryModel $model */
+    $model = $this->getModel();
+
+		$this->state = $model->getState();
+		$this->item  = $model->getItem();
+		$this->form  = $model->getForm();
 
 		// JS to deactivate filesystem form field
 		$js  = 'var callback = function() {';
@@ -55,9 +59,9 @@ class HtmlView extends JoomGalleryView
 		$this->filesystem_js = $js;
 
 		// Check for errors.
-		if(count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -75,7 +79,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
-		$toolbar = Toolbar::getInstance('toolbar');
+		/** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Config/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Config/HtmlView.php
@@ -17,6 +17,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Layout\LayoutHelper;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
 /**
@@ -45,16 +46,19 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state            = $this->get('State');
-		$this->item             = $this->get('Item');
-		$this->form             = $this->get('Form');
-    $this->fieldsets        = $this->get('Fieldsets');
+		/** @var ConfigModel $model */
+    $model = $this->getModel();
+
+		$this->state            = $model->getState();
+		$this->item             = $model->getItem();
+		$this->form             = $model->getForm();
+		$this->fieldsets        = $model->getFieldsets();
     $this->is_global_config = ($this->item->id === 1) ? true : false;
 
-		// Check for errors
-		if(\count($errors = $this->get('Errors')))
+		// Check for errors.
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -72,7 +76,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
-		$toolbar = Toolbar::getInstance('toolbar');
+		/** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Config/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Config/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends JoomGalleryView
 
 		if(isset($this->item->checked_out))
 		{
-			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->id);
 		}
 		else
 		{

--- a/administrator/com_joomgallery/src/View/Config/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Config/HtmlView.php
@@ -77,7 +77,7 @@ class HtmlView extends JoomGalleryView
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
 		/** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -76,7 +76,7 @@ class HtmlView extends JoomGalleryView
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CONFIG_SETS'), "sliders-h");
 
     /** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
     $formPath = _JOOM_PATH_ADMIN . '/src/View/Configs';

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\HTML\Helpers\Sidebar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
@@ -42,16 +43,19 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    $this->state         = $this->get('State');
-    $this->items         = $this->get('Items');		
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+    /** @var ConfigsModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if(count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -71,10 +75,11 @@ class HtmlView extends JoomGalleryView
 	{
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_CONFIG_SETS'), "sliders-h");
 
-    $toolbar = Toolbar::getInstance('toolbar');
+    /** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
-    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Configs';
+    $formPath = _JOOM_PATH_ADMIN . '/src/View/Configs';
 
     // Show button back to control panel
     $html = '<a href="index.php?option=com_joomgallery&amp;view=control" class="btn btn-primary"><span class="icon-arrow-left-4" title="'.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'"></span> '.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'</a>';

--- a/administrator/com_joomgallery/src/View/Control/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Control/HtmlView.php
@@ -86,7 +86,7 @@ class HtmlView extends JoomGalleryView
   protected function addToolbar()
   {
     /** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
     // Images button
     $html = '<a href="index.php?option=com_joomgallery&amp;view=images" class="btn btn-primary"><span class="icon-images" title="'.Text::_('COM_JOOMGALLERY_IMAGES').'"></span> '.Text::_('COM_JOOMGALLERY_IMAGES').'</a>';

--- a/administrator/com_joomgallery/src/View/Control/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Control/HtmlView.php
@@ -38,20 +38,23 @@ class HtmlView extends JoomGalleryView
   {
     ToolBarHelper::title(Text::_('COM_JOOMGALLERY_CONTROL_PANEL') , 'home');
 
+    /** @var ControlModel $model */
+    $model = $this->getModel();
+
     // get module positions in cpanel
     $this->modules = ModuleHelper::getModules('joom_cpanel');
 
     // get statistic data
-    $this->statisticdata = $this->get('StatisticData');
+    $this->statisticdata = $model->getStatisticData();
 
     // get gallery info data
-    $this->galleryinfodata = $this->get('GalleryInfoData');
+    $this->galleryinfodata = $model->getGalleryInfoData();
 
     // get official extensions data
-    $this->galleryofficialextensionsdata = $this->get('OfficialExtensionsData');
+    $this->galleryofficialextensionsdata = $model->getOfficialExtensionsData();
 
     // get installed extensions data
-    $this->galleryinstalledextensionsdata = $this->get('InstalledExtensionsData');
+    $this->galleryinstalledextensionsdata = $model->getInstalledExtensionsData();
 
     // get php system info
     $this->php_settings = [
@@ -82,7 +85,8 @@ class HtmlView extends JoomGalleryView
    */
   protected function addToolbar()
   {
-    $toolbar = Toolbar::getInstance('toolbar');
+    /** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
     // Images button
     $html = '<a href="index.php?option=com_joomgallery&amp;view=images" class="btn btn-primary"><span class="icon-images" title="'.Text::_('COM_JOOMGALLERY_IMAGES').'"></span> '.Text::_('COM_JOOMGALLERY_IMAGES').'</a>';

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -116,7 +116,7 @@ class HtmlView extends JoomGalleryView
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
 		/** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -123,7 +123,7 @@ class HtmlView extends JoomGalleryView
 
 		if(isset($this->item->checked_out))
 		{
-			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->id);
 		}
 		else
 		{

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
@@ -43,9 +44,12 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state      = $this->get('State');
-		$this->item       = $this->get('Item');
-		$this->form       = $this->get('Form');
+		/** @var ImageModel $model */
+    $model = $this->getModel();
+
+		$this->state      = $model->getState();
+		$this->item       = $model->getItem();
+		$this->form       = $model->getForm();
     $this->config     = JoomHelper::getService('config');
     $this->imagetypes = JoomHelper::getRecords('imagetypes');
     $rating           = JoomHelper::getRating($this->item->id);
@@ -58,9 +62,9 @@ class HtmlView extends JoomGalleryView
     }
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
     if($this->_layout == 'upload')
@@ -111,7 +115,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
-		$toolbar = Toolbar::getInstance('toolbar');
+		/** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -13,6 +13,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Router\Route;
+use \Joomla\Component\Media\Administrator\Exception\InvalidPathException;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
@@ -46,6 +47,9 @@ class RawView extends JoomGalleryView
       $this->app->redirect(Route::_('index.php', false), 403);
     }
 
+    /** @var ImageModel $model */
+    $model = $this->getModel();
+
     // Choose the filesystem adapter
     $adapter = '';
     if($id === 0 || $id === 'null')
@@ -57,7 +61,7 @@ class RawView extends JoomGalleryView
     else
     {
       // Take the adapter from the image object
-      $img_obj = $this->get('Item');
+      $img_obj = $model->getItem();
       $adapter = $img_obj->filesystem;
     }
     

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -80,7 +80,7 @@ class HtmlView extends JoomGalleryView
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_IMAGES'), "image");
 
     /** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
     $formPath = _JOOM_PATH_ADMIN . '/src/View/Images';

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\HTML\Helpers\Sidebar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use \Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
@@ -43,19 +44,22 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    $this->state         = $this->get('State');
-		$this->items         = $this->get('Items');    
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+    /** @var ImagesModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
     
 		// Check if filesystem plugins are available
 		JoomHelper::checkFilesystems();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -75,10 +79,11 @@ class HtmlView extends JoomGalleryView
   {
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_IMAGES'), "image");
 
-    $toolbar = Toolbar::getInstance('toolbar');
+    /** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
-    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Images';
+    $formPath = _JOOM_PATH_ADMIN . '/src/View/Images';
 
     // Show button back to control panel
     $html = '<a href="index.php?option=com_joomgallery&amp;view=control" class="btn btn-primary"><span class="icon-arrow-left-4" title="'.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'"></span> '.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'</a>';

--- a/administrator/com_joomgallery/src/View/JoomGalleryView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryView.php
@@ -16,6 +16,7 @@ use \Joomla\Uri\Uri;
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Menu\MenuItem;
 use \Joomla\CMS\Language\Text;
+use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Access\AccessInterface;
 
@@ -137,6 +138,27 @@ class JoomGalleryView extends BaseHtmlView
 	{
 		return isset($this->state->{$state}) ? $this->state->{$state} : false;
 	}
+
+  /**
+	 * Returns the toolbar
+	 *
+	 * @return Toolbar
+	 */
+  public function getToolbar(): Toolbar
+  {
+    try
+    {
+      // Try it the new/modern way
+      $toolbar = $this->getDocument()->getToolbar();
+    }
+    catch(\Throwable $th)
+    {
+      // Try it the old way
+      $toolbar = Toolbar::getInstance('toolbar');
+    }
+
+    return $toolbar;
+  }
 
   
   /**

--- a/administrator/com_joomgallery/src/View/Migration/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Migration/HtmlView.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
 /**
@@ -37,8 +38,11 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    $this->script  = $this->get('Script');
-    $this->scripts = $this->get('Scripts');    
+    /** @var MigrationModel $model */
+    $model = $this->getModel();
+
+    $this->script  = $model->getScript();
+    $this->scripts = $model->getScripts();
     $this->layout  = $this->app->input->get('layout', 'default', 'cmd');
     $this->error   = array();
 
@@ -60,7 +64,7 @@ class HtmlView extends JoomGalleryView
       else
       {
         // Try to load the migration params
-        $this->params = $this->get('Params');
+        $this->params = $model->getParams();
 
         // Check if migration params exist
         if(\is_null($this->params) && $this->layout != 'step1')
@@ -74,7 +78,7 @@ class HtmlView extends JoomGalleryView
       {
         case 'step1':
           // Load migration form
-          $this->form = $this->get('Form');
+          $this->form = $model->getForm();
           break;
 
         case 'step2':
@@ -86,19 +90,19 @@ class HtmlView extends JoomGalleryView
         case 'step3':
           // Data for the migration view
           $this->precheck     = $this->app->getUserState(_JOOM_OPTION.'.migration.'.$this->script->name.'.step2.success', false);
-          $this->migrateables = $this->get('Migrateables');
+          $this->migrateables = $model->getMigrateables();
           $this->migration    = $this->app->getUserState(_JOOM_OPTION.'.migration.'.$this->script->name.'.step3.results', array());
-          $this->dependencies = $this->get('Dependencies');
-          $this->completed    = $this->get('Completed');
+          $this->dependencies = $model->getDependencies();
+          $this->completed    = $model->getCompleted();
           break;
 
         case 'step4':
           // Load postcheck results
           $this->postcheck      = $this->app->getUserState(_JOOM_OPTION.'.migration.'.$this->script->name.'.step4.results', array());
           $this->success        = $this->app->getUserState(_JOOM_OPTION.'.migration.'.$this->script->name.'.step4.success', false);
-          $this->sourceDeletion = $this->get('sourceDeletion');
+          $this->sourceDeletion = $model->getSourceDeletion();
 
-          $this->openMigrations = $this->get('IdList');
+          $this->openMigrations = $model->getIdList();
           if(!empty($this->openMigrations) && \key_exists($this->script->name, $this->openMigrations))
           {
             $this->openMigrations = $this->openMigrations[$this->script->name];
@@ -122,13 +126,13 @@ class HtmlView extends JoomGalleryView
       }
 
       // ID list of open migrations
-      $this->openMigrations = $this->get('IdList');
+      $this->openMigrations = $model->getIdList();
     }
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		parent::display($tpl);

--- a/administrator/com_joomgallery/src/View/Tag/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tag/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
 /**
@@ -41,14 +42,17 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state = $this->get('State');
-		$this->item  = $this->get('Item');
-		$this->form  = $this->get('Form');
+		/** @var ImageModel $model */
+    $model = $this->getModel();
+
+		$this->state = $model->getState();
+		$this->item  = $model->getItem();
+		$this->form  = $model->getForm();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -66,7 +70,8 @@ class HtmlView extends JoomGalleryView
 	{
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
-		$toolbar = Toolbar::getInstance('toolbar');
+		/** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Tag/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tag/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends JoomGalleryView
 		Factory::getApplication()->input->set('hidemainmenu', true);
 
 		/** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
 		$user  = Factory::getApplication()->getIdentity();
 		$isNew = ($this->item->id == 0);

--- a/administrator/com_joomgallery/src/View/Tag/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tag/HtmlView.php
@@ -78,7 +78,7 @@ class HtmlView extends JoomGalleryView
 
 		if(isset($this->item->checked_out))
 		{
-			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
+			$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->id);
 		}
 		else
 		{

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -76,7 +76,7 @@ class HtmlView extends JoomGalleryView
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_TAGS'), "tags");
 
     /** @var Toolbar $model */
-    $toolbar = $this->getDocument()->getToolbar();
+    $toolbar = $this->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
     $formPath = _JOOM_PATH_ADMIN . '/src/View/Tags';

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
 use \Joomla\CMS\HTML\Helpers\Sidebar;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
@@ -42,16 +43,19 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    $this->state         = $this->get('State');	
-    $this->items         = $this->get('Items');			
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+    /** @var TagsModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new \Exception(implode("\n", $errors));
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();
@@ -71,10 +75,11 @@ class HtmlView extends JoomGalleryView
   {
     ToolbarHelper::title(Text::_('COM_JOOMGALLERY_TAGS'), "tags");
 
-    $toolbar = Toolbar::getInstance('toolbar');
+    /** @var Toolbar $model */
+    $toolbar = $this->getDocument()->getToolbar();
 
     // Check if the form exists before showing the add/edit buttons
-    $formPath = JPATH_COMPONENT_ADMINISTRATOR . '/src/View/Tags';
+    $formPath = _JOOM_PATH_ADMIN . '/src/View/Tags';
 
     // Show button back to control panel
     $html = '<a href="index.php?option=com_joomgallery&amp;view=control" class="btn btn-primary"><span class="icon-arrow-left-4" title="'.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'"></span> '.Text::_('COM_JOOMGALLERY_CONTROL_PANEL').'</a>';

--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -28,7 +28,7 @@ $wa->useStyle('com_joomgallery.admin')
    ->useScript('multiselect');
 
 $user      = $this->app->getIdentity();
-$userId    = $user->get('id');
+$userId    = $user->id;
 $listOrder = $this->state->get('list.ordering');
 $listDirn  = $this->state->get('list.direction');
 $canOrder  = $this->getAcl()->checkACL('editstate', 'com_joomgallery');

--- a/administrator/com_joomgallery/tmpl/config/edit.php
+++ b/administrator/com_joomgallery/tmpl/config/edit.php
@@ -26,7 +26,7 @@ HTMLHelper::_('bootstrap.tooltip');
 // Import modal
 $importModal = array(
   'selector' => 'import_modal',
-  'params'   => array('title'  => $this->item->get('title').': '.Text::_($this->form->getField('import_json')->getAttribute('title')),
+  'params'   => array('title'  => $this->item->title.': '.Text::_($this->form->getField('import_json')->getAttribute('title')),
                       'footer' => '<button class="btn btn-primary" onclick="submitImport(this, event)" aria-label="'.Text::_('COM_JOOMGALLERY_IMPORT').'">'.Text::_('COM_JOOMGALLERY_IMPORT').'</button>'
                      ),
   'body'     => $this->form->renderField('import_json'),
@@ -39,7 +39,7 @@ $js .= '};';
 // Note modal
 $noteModal = array(
   'selector' => 'note_modal',
-  'params'   => array('title'  => $this->item->get('title').': '.Text::_($this->form->getField('note')->getAttribute('title')),
+  'params'   => array('title'  => $this->item->title.': '.Text::_($this->form->getField('note')->getAttribute('title')),
                       'footer' => '<button class="btn btn-primary" data-bs-dismiss="modal" onclick="event.preventDefault()" aria-label="'.Text::_('JCLOSE').'">'.Text::_('JCLOSE').'</button>'
                     ),
   'body'     => $this->form->renderField('note'),

--- a/administrator/com_joomgallery/tmpl/configs/default.php
+++ b/administrator/com_joomgallery/tmpl/configs/default.php
@@ -25,7 +25,7 @@ $wa->useStyle('com_joomgallery.admin')
 HTMLHelper::_('bootstrap.tooltip');
 
 $user      = $this->app->getIdentity();
-$userId    = $user->get('id');
+$userId    = $user->id;
 $listOrder = $this->state->get('list.ordering');
 $listDirn  = $this->state->get('list.direction');
 $canOrder  = $this->getAcl()->checkACL('editstate', 'com_joomgallery');

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -29,7 +29,7 @@ $wa->useStyle('com_joomgallery.admin')
    ->useScript('multiselect');
 
 $user      = $this->app->getIdentity();
-$userId    = $user->get('id');
+$userId    = $user->id;
 $listOrder = $this->state->get('list.ordering');
 $listDirn  = $this->state->get('list.direction');
 $canOrder  = $this->getAcl()->checkACL('editstate', 'com_joomgallery');

--- a/administrator/com_joomgallery/tmpl/tags/default.php
+++ b/administrator/com_joomgallery/tmpl/tags/default.php
@@ -25,7 +25,7 @@ $wa->useStyle('com_joomgallery.admin')
    ->useScript('multiselect');
 
 $user      = $this->app->getIdentity();
-$userId    = $user->get('id');
+$userId    = $user->id;
 $listOrder = $this->state->get('list.ordering');
 $listDirn  = $this->state->get('list.direction');
 $canOrder  = $this->getAcl()->checkACL('editstate', 'com_joomgallery');

--- a/docs/Codestyleguide.md
+++ b/docs/Codestyleguide.md
@@ -175,7 +175,7 @@ foreach ($array as $key=>$integer)
 if(  (  (   ($this->_config->get('jg_showdetailfavourite') == 0 && $this->_user->get('aid') < 1)
           || ($this->_config->get('jg_showdetailfavourite') == 1 && $this->_user->get('aid') < 2)
         )
-      ^ ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && $this->_user->get('id') < 1)
+      ^ ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && $this->_user->id < 1)
       )
     || $this->_config->get('jg_favourites') == 0
   )

--- a/plugins/privacy/joomgallery/src/Extension/JoomgalleryPrivacy.php
+++ b/plugins/privacy/joomgallery/src/Extension/JoomgalleryPrivacy.php
@@ -35,7 +35,7 @@ final class JoomgalleryPrivacy extends PrivacyPlugin
 	 *
 	 * @since   4.0.0
 	 */
-	public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+	public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
 	{
 		if (!$user)
 		{
@@ -46,12 +46,13 @@ final class JoomgalleryPrivacy extends PrivacyPlugin
 		$domain    = $this->createDomain('user_image', 'joomla_user_image_data');
 		$domains[] = $domain;
 
-		$query = $this->db->getQuery(true)
+		$db = $this->getDatabase();
+		$query = $db->getQuery(true)
 			->select('*')
-			->from($this->db->quoteName('#__joomgallery'))
-			->where($this->db->quoteName('created_by') . ' = ' . (int) $user->id);
+			->from($db->quoteName('#__joomgallery'))
+			->where($db->quoteName('created_by') . ' = ' . (int) $user->id);
 
-		$items = $this->db->setQuery($query)->loadObjectList();
+		$items = $db->setQuery($query)->loadObjectList();
 
 		foreach ($items as $item)
 		{
@@ -75,7 +76,7 @@ final class JoomgalleryPrivacy extends PrivacyPlugin
 	 *
 	 * @since   4.0.0
 	 */
-	public function onPrivacyRemoveData(RequestTable $request, User $user = null)
+	public function onPrivacyRemoveData(RequestTable $request, ?User $user = null)
 	{
 		// This plugin only processes data for registered user accounts
 		if (!$user)
@@ -83,15 +84,15 @@ final class JoomgalleryPrivacy extends PrivacyPlugin
 			return;
 		}
 
-		$db = $this->db;
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true);
 
 		$query->clear()
 			->delete($db->quoteName('#__joomgallery'))
-			->where($this->db->quoteName('created_by') . ' = ' . (int) $user->id);
+			->where($db->quoteName('created_by') . ' = ' . (int) $user->id);
 
 		$db->setQuery($query)
-			->execute();
+			 ->execute();
 	}
 }

--- a/plugins/system/joomgallery/src/Extension/Joomgallery.php
+++ b/plugins/system/joomgallery/src/Extension/Joomgallery.php
@@ -17,7 +17,9 @@ use Joomla\Event\Priority;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Event\EventInterface;
 use Joomla\Event\SubscriberInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\Event\DispatcherAwareInterface;
 use Joomla\CMS\Event\Model\AfterCleanCacheEvent;
 use Joomla\CMS\Event\Result\ResultAwareInterface;
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
@@ -28,8 +30,10 @@ use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
  * @package JoomGallery
  * @since   4.0.0
  */
-final class Joomgallery extends CMSPlugin implements SubscriberInterface
+final class Joomgallery extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
 {
+  use DispatcherAwareTrait;
+
   /**
    * Global database object
    *

--- a/script.php
+++ b/script.php
@@ -611,6 +611,12 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     require_once $multipleassetstable_path;
 
+    // Load LegacyDatabaseTrait
+    $legacydatabasetrait_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'LegacyDatabaseTrait.php';
+    $legacydatabasetraitClass = '\\Joomgallery\\Component\\Joomgallery\\Administrator\\Table\\LegacyDatabaseTrait';
+
+    require_once $legacydatabasetrait_path;
+
     // Load CategoryTable
     $class_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'CategoryTable.php';
     $tableClass = '\\Joomgallery\\Component\\Joomgallery\\Administrator\\Table\\CategoryTable';

--- a/script.php
+++ b/script.php
@@ -605,17 +605,17 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     require_once $multipleassetstabletrait_path;
 
-    // Load MultipleAssetsTable
-    $multipleassetstable_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'MultipleAssetsTable.php';
-    $multipleassetstableClass = '\\Joomgallery\\Component\\Joomgallery\\Administrator\\Table\\MultipleAssetsTable';
-
-    require_once $multipleassetstable_path;
-
     // Load LegacyDatabaseTrait
     $legacydatabasetrait_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'LegacyDatabaseTrait.php';
     $legacydatabasetraitClass = '\\Joomgallery\\Component\\Joomgallery\\Administrator\\Table\\LegacyDatabaseTrait';
 
     require_once $legacydatabasetrait_path;
+
+    // Load MultipleAssetsTable
+    $multipleassetstable_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'MultipleAssetsTable.php';
+    $multipleassetstableClass = '\\Joomgallery\\Component\\Joomgallery\\Administrator\\Table\\MultipleAssetsTable';
+
+    require_once $multipleassetstable_path;
 
     // Load CategoryTable
     $class_path = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Table'.DIRECTORY_SEPARATOR.'CategoryTable.php';

--- a/site/com_joomgallery/src/Controller/JoomBaseController.php
+++ b/site/com_joomgallery/src/Controller/JoomBaseController.php
@@ -55,7 +55,7 @@ class JoomBaseController extends BaseController
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+	public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
 	{
 		parent::__construct($config, $factory, $app, $input);
 

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -610,7 +610,7 @@ class CategoryModel extends JoomItemModel
    * @since   4.0.0
    * @throws Exception
    */
-  public function getUnpublishedParents(int $pk = null, bool $approved = false): array
+  public function getUnpublishedParents(?int $pk = null, bool $approved = false): array
   {
     if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
     {
@@ -627,7 +627,7 @@ class CategoryModel extends JoomItemModel
     }
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
@@ -675,7 +675,7 @@ class CategoryModel extends JoomItemModel
    *
    * @since   4.0.0
    */
-  public function getProtectedParents(int $pk = null): array
+  public function getProtectedParents(?int $pk = null): array
   {
     if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
     {
@@ -692,7 +692,7 @@ class CategoryModel extends JoomItemModel
     }
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));
@@ -732,7 +732,7 @@ class CategoryModel extends JoomItemModel
    *
    * @since   4.0.0
    */
-  public function getAccessibleParents(int $pk = null): array
+  public function getAccessibleParents(?int $pk = null): array
   {
     if(\is_null($pk) && !\is_null($this->item) && isset($this->item->id))
     {
@@ -752,7 +752,7 @@ class CategoryModel extends JoomItemModel
     $user  = $this->app->getIdentity();
 
     // Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
     $query->select('id');
     $query->from($db->quoteName(_JOOM_TABLE_CATEGORIES));

--- a/site/com_joomgallery/src/Model/JoomItemModel.php
+++ b/site/com_joomgallery/src/Model/JoomItemModel.php
@@ -210,7 +210,7 @@ abstract class JoomItemModel extends ItemModel
 			// Attempt to check the row out.
 			if(\method_exists($table, 'checkout'))
 			{
-				if(!$table->checkout($user->get('id'), $id))
+				if(!$table->checkout($user->id, $id))
 				{
 					return false;
 				}

--- a/site/com_joomgallery/src/Service/JG3LegacyRoter.php
+++ b/site/com_joomgallery/src/Service/JG3LegacyRoter.php
@@ -464,7 +464,7 @@ class JG3LegacyRouter implements RouterInterface
   
     $vars = array();
   
-    $language = Factory::getLanguage();
+    $language = Factory::getApplication()->getLanguage();
     $language->load('com_joomgallery');
   
     $segment = str_replace(':', '-', $segments[0]);

--- a/site/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categories/HtmlView.php
@@ -49,17 +49,20 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state         = $this->get('State');
-    $this->params        = $this->get('Params');
-		$this->items         = $this->get('Items');
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+		/** @var CategoriesModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+		$this->params        = $model->getParams();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
     // Check if is userspace is enabled

--- a/site/com_joomgallery/src/View/Category/HtmlView.php
+++ b/site/com_joomgallery/src/View/Category/HtmlView.php
@@ -59,14 +59,16 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-    // Current category item
-		$this->state  = $this->get('State');
-		$this->params = $this->get('Params');
+		/** @var CategoryModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
+		$this->params = $model->getParams();
     $this->menu   = $this->app->getMenu()->getActive();
 
 		$loaded = true;
 		try {
-			$this->item = $this->get('Item');
+			$this->item = $model->getItem();
 		}
 		catch (\Exception $e)
 		{
@@ -91,25 +93,25 @@ class HtmlView extends JoomGalleryView
 		if(!$this->item->pw_protected)
 		{
 			// Load parent category
-			$this->item->parent = $this->get('Parent');
+			$this->item->parent = $model->getParent();
 
 			// Load subcategories
 			$this->item->children = new \stdClass();
-			$this->item->children->items         = $this->get('Children');
-			$this->item->children->pagination    = $this->get('ChildrenPagination');
+			$this->item->children->items         = $model->getChildren();
+			$this->item->children->pagination    = $model->getChildrenPagination();
 
 			// Load images
 			$this->item->images = new \stdClass();
-			$this->item->images->items         = $this->get('Images');
-			$this->item->images->pagination    = $this->get('ImagesPagination');
-			$this->item->images->filterForm    = $this->get('ImagesFilterForm');
-			$this->item->images->activeFilters = $this->get('ImagesActiveFilters');
+			$this->item->images->items         = $model->getImages();
+			$this->item->images->pagination    = $model->getImagesPagination();
+			$this->item->images->filterForm    = $model->getImagesFilterForm();
+			$this->item->images->activeFilters = $model->getImagesActiveFilters();
 		}
 
     // Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->_prepareDocument();

--- a/site/com_joomgallery/src/View/Category/JsonView.php
+++ b/site/com_joomgallery/src/View/Category/JsonView.php
@@ -39,12 +39,14 @@ class JsonView extends JoomGalleryJsonView
 	 */
 	public function display($tpl = null)
 	{
-    // Current category item
-		$this->state  = $this->get('State');
+    /** @var CategoryModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
 
     $loaded = true;
 		try {
-			$this->item = $this->get('Item');
+			$this->item = $model->getItem();
 		}
 		catch (\Exception $e)
 		{
@@ -66,18 +68,18 @@ class JsonView extends JoomGalleryJsonView
     }
 
     // Load parent category
-    $this->item->parent = $this->get('Parent');
+    $this->item->parent = $model->getParent();
 
     // Load subcategories
     $this->item->children = new \stdClass();
-    $this->item->children->items = $this->get('Children');
+    $this->item->children->items = $model->getChildren();
 
     // Load images
     $this->item->images = new \stdClass();
-    $this->item->images->items = $this->get('Images');
+    $this->item->images->items = $model->getImages();
 
     // Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(\count($errors = $model->getErrors()))
 		{
       $this->error = true;
       $this->output($errors);

--- a/site/com_joomgallery/src/View/Categoryform/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categoryform/HtmlView.php
@@ -75,15 +75,17 @@ class HtmlView extends JoomGalleryView
 		{
 			return;
 		}
-		
-		// Load state and params
-		$this->state  = $this->get('State');
-		$this->params = $this->get('Params');
-		$this->item   = $this->get('Item');
-		$this->form		= $this->get('Form');
+
+		/** @var CategoryfromModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
+		$this->params = $model->getParams();
+		$this->item   = $model->getItem();
+		$this->form   = $model->getForm();
 
     // Get return page
-    $this->return_page = $this->get('ReturnPage');		
+    $this->return_page = $model->getReturnPage();		
 
     // Check access view level
 		if(!\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
@@ -93,9 +95,9 @@ class HtmlView extends JoomGalleryView
     }
 		
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		$this->_prepareDocument();

--- a/site/com_joomgallery/src/View/Gallery/HtmlView.php
+++ b/site/com_joomgallery/src/View/Gallery/HtmlView.php
@@ -14,6 +14,7 @@ namespace Joomgallery\Component\Joomgallery\Site\View\Gallery;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Language\Text;
+use \Joomla\CMS\MVC\View\GenericDataException;
 use \Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 
 /**
@@ -51,20 +52,23 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state  = $this->get('State');
-		$this->params = $this->get('Params');
-		$this->item   = $this->get('Item');
+		/** @var GalleryModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
+		$this->params = $model->getParams();
+		$this->item   = $model->getItem();
 
     // Load images
     $this->item->images = new \stdClass();
-    $this->item->images->items      = $this->get('Images');
-    $this->item->images->pagination = $this->get('ImagesPagination');
+    $this->item->images->items      = $model->getImages();
+    $this->item->images->pagination = $model->getImagesPagination();
 
     // Check for errors.
-    if(\count($errors = $this->get('Errors')))
-    {
-      throw new GenericDataException(\implode("\n", $errors), 500);
-    }
+		if(count($errors = $model->getErrors()))
+		{
+			throw new GenericDataException(implode("\n", $errors), 500);
+		}
 
     $this->_prepareDocument();
 

--- a/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -53,49 +53,52 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state  = $this->get('State');
-		$this->params = $this->get('Params');
+		/** @var ImageModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
+		$this->params = $model->getParams();
 
 		$loaded = true;
 		try {
-			$this->item = $this->get('Item');
+			$this->item = $model->getItem();
 		}
 		catch (\Exception $e)
 		{
 			$loaded = false;
 		}
 
-		$temp = $this->get('CategoryProtected');
+		$temp = $model->getCategoryProtected();
 
 		// Check if category is protected?
-		if($loaded && $this->get('CategoryProtected'))
+		if($loaded && $model->getCategoryProtected())
 		{
 			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_IMAGE_CAT_PROTECTED'), 'error');
 			$this->app->redirect(Route::_('index.php?option='._JOOM_OPTION.'&view=category&id='.$this->item->protectedParents[0]));
 		}
 
-		$temp = $this->get('CategoryPublished');
+		$temp = $model->getCategoryPublished();
 
 		// Check published and approved state
-		if(!$loaded || !$this->get('CategoryPublished') ||$this->item->published !== 1 || $this->item->approved !== 1)
+		if(!$loaded || !$model->getCategoryPublished() ||$this->item->published !== 1 || $this->item->approved !== 1)
 		{
 			$this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
 			return;
 		}
 
-		$temp = $this->get('CategoryAccess');
+		$temp = $model->getCategoryAccess();
 
     // Check access view level
-		if(!$this->get('CategoryAccess') || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+		if(!$model->getCategoryAccess() || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
     {
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'), 'error');
 			return;
     }
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
 		// Load additional information

--- a/site/com_joomgallery/src/View/Image/RawView.php
+++ b/site/com_joomgallery/src/View/Image/RawView.php
@@ -182,8 +182,11 @@ class RawView extends AdminRawView
     $loaded = true;
     $access = true;
 
+    /** @var ImageModel $model */
+    $model = $this->getModel();
+
 		try {
-			$this->item = $this->get('Item');
+			$this->item = $model->getItem();
 		}
 		catch (\Exception $e)
 		{
@@ -191,19 +194,19 @@ class RawView extends AdminRawView
 		}
 
     // Check if category is protected?
-		if($loaded && $this->get('CategoryProtected'))
+		if($loaded && $model->getCategoryProtected())
 		{
       $access = false;
 		}
 
     // Check published state
-		if(!$loaded || !$this->get('CategoryPublished') || $this->item->published !== 1 || $this->item->approved !== 1)
+		if(!$loaded || !$model->getCategoryPublished() || $this->item->published !== 1 || $this->item->approved !== 1)
 		{
 			$access = false;
 		}
 
     // Check access view level
-		if(!$this->get('CategoryAccess') || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
+		if(!$model->getCategoryAccess() || !\in_array($this->item->access, $this->getCurrentUser()->getAuthorisedViewLevels()))
     {
       $access = false;
     }

--- a/site/com_joomgallery/src/View/Imageform/HtmlView.php
+++ b/site/com_joomgallery/src/View/Imageform/HtmlView.php
@@ -76,18 +76,21 @@ class HtmlView extends JoomGalleryView
 			return;
 		}
 
-		$this->state  = $this->get('State');
-		$this->params = $this->get('Params');
-		$this->item   = $this->get('Item');
-		$this->form		= $this->get('Form');
+		/** @var ImagefromModel $model */
+    $model = $this->getModel();
+
+    $this->state  = $model->getState();
+		$this->params = $model->getParams();
+		$this->item   = $model->getItem();
+		$this->form   = $model->getForm();
 
     // Get return page
-    $this->return_page = $this->get('ReturnPage');
+    $this->return_page = $model->getReturnPage();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
     // Check access view level

--- a/site/com_joomgallery/src/View/Images/HtmlView.php
+++ b/site/com_joomgallery/src/View/Images/HtmlView.php
@@ -51,17 +51,20 @@ class HtmlView extends JoomGalleryView
 	 */
 	public function display($tpl = null)
 	{
-		$this->state         = $this->get('State');
-    $this->params        = $this->get('Params');
-		$this->items         = $this->get('Items');
-		$this->pagination    = $this->get('Pagination');
-		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
+		/** @var ImagesModel $model */
+    $model = $this->getModel();
+
+    $this->state         = $model->getState();
+		$this->params        = $model->getParams();
+    $this->items         = $model->getItems();		
+		$this->pagination    = $model->getPagination();
+		$this->filterForm    = $model->getFilterForm();
+		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if(\count($errors = $this->get('Errors')))
+		if(count($errors = $model->getErrors()))
 		{
-			throw new GenericDataException(\implode("\n", $errors), 500);
+			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
     // Check if is userspace is enabled

--- a/site/com_joomgallery/tmpl/categories/default.php
+++ b/site/com_joomgallery/tmpl/categories/default.php
@@ -110,7 +110,7 @@ if($saveOrder && !empty($this->items))
                   $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.category', $item->id);
                   $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.category', $item->id);
                   $canChange  = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $item->id);
-									$canCheckin = $canChange || $item->checked_out == $this->getUser()->id;
+									$canCheckin = $canChange || $item->checked_out == $this->getCurrentUser()->id;
 									$disabled   = ($item->checked_out > 0) ? 'disabled' : '';
                 
 									// Get the parents of item for sorting

--- a/site/com_joomgallery/tmpl/categories/default.php
+++ b/site/com_joomgallery/tmpl/categories/default.php
@@ -110,7 +110,7 @@ if($saveOrder && !empty($this->items))
                   $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.category', $item->id);
                   $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.category', $item->id);
                   $canChange  = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $item->id);
-									$canCheckin = $canChange || $item->checked_out == Factory::getUser()->id;
+									$canCheckin = $canChange || $item->checked_out == $this->getUser()->id;
 									$disabled   = ($item->checked_out > 0) ? 'disabled' : '';
                 
 									// Get the parents of item for sorting

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -121,7 +121,7 @@ else
   $canAddImg  = true;
 }
 $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.category', $this->item->id);
-$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $this->item->id) || $this->item->checked_out == $this->getUser()->id;
+$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $this->item->id) || $this->item->checked_out == $this->getCurrentUser()->id;
 $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id, $this->item->parent_id, $this->item->language, $this->getLayout()));
 ?>
 

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -121,7 +121,7 @@ else
   $canAddImg  = true;
 }
 $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.category', $this->item->id);
-$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $this->item->id) || $this->item->checked_out == Factory::getUser()->id;
+$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category', $this->item->id) || $this->item->checked_out == $this->getUser()->id;
 $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id, $this->item->parent_id, $this->item->language, $this->getLayout()));
 ?>
 

--- a/site/com_joomgallery/tmpl/categoryform/default.php
+++ b/site/com_joomgallery/tmpl/categoryform/default.php
@@ -24,7 +24,7 @@ $wa->useScript('keepalive')
    ->useStyle('com_joomgallery.site');
 
 // Load admin language file
-$lang = Factory::getLanguage();
+$lang = Factory::getApplication()->getLanguage();
 $lang->load('com_joomgallery', JPATH_SITE);
 $lang->load('com_joomgallery', JPATH_ADMINISTRATOR);
 $lang->load('joomla', JPATH_ADMINISTRATOR);

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -43,7 +43,7 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
 // Access check
 $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.image', $this->item->id, $this->item->catid, true);
 $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.image', $this->item->id, $this->item->catid, true);
-$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $this->item->id, $this->item->catid, true) || $this->item->checked_out == Factory::getUser()->id;
+$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $this->item->id, $this->item->catid, true) || $this->item->checked_out == $this->getUser()->id;
 $returnURL  = base64_encode(JoomHelper::getViewRoute('image', $this->item->id, $this->item->catid, $this->item->language, $this->getLayout()));
 
 // Tags

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -43,7 +43,7 @@ $wa->useStyle('com_joomgallery.jg-icon-font');
 // Access check
 $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.image', $this->item->id, $this->item->catid, true);
 $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.image', $this->item->id, $this->item->catid, true);
-$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $this->item->id, $this->item->catid, true) || $this->item->checked_out == $this->getUser()->id;
+$canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $this->item->id, $this->item->catid, true) || $this->item->checked_out == $this->getCurrentUser()->id;
 $returnURL  = base64_encode(JoomHelper::getViewRoute('image', $this->item->id, $this->item->catid, $this->item->language, $this->getLayout()));
 
 // Tags

--- a/site/com_joomgallery/tmpl/imageform/default.php
+++ b/site/com_joomgallery/tmpl/imageform/default.php
@@ -24,7 +24,7 @@ $wa->useScript('keepalive')
    ->useStyle('com_joomgallery.site');
 
 // Load admin language file
-$lang = Factory::getLanguage();
+$lang = Factory::getApplication()->getLanguage();
 $lang->load('com_joomgallery', JPATH_SITE);
 $lang->load('com_joomgallery', JPATH_ADMINISTRATOR);
 $lang->load('joomla', JPATH_ADMINISTRATOR);

--- a/site/com_joomgallery/tmpl/images/default.php
+++ b/site/com_joomgallery/tmpl/images/default.php
@@ -114,7 +114,7 @@ if($saveOrder && !empty($this->items))
                   $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.image', $item->id, $item->catid, true);
                   $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.image', $item->id, $item->catid, true);
                   $canChange  = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $item->id, $item->catid, true);
-                  $canCheckin = $canChange || $item->checked_out == Factory::getUser()->id;
+                  $canCheckin = $canChange || $item->checked_out == $this->getUser()->id;
                   $disabled   = ($item->checked_out > 0) ? 'disabled' : '';
                 ?>
 

--- a/site/com_joomgallery/tmpl/images/default.php
+++ b/site/com_joomgallery/tmpl/images/default.php
@@ -114,7 +114,7 @@ if($saveOrder && !empty($this->items))
                   $canEdit    = $this->getAcl()->checkACL('edit', 'com_joomgallery.image', $item->id, $item->catid, true);
                   $canDelete  = $this->getAcl()->checkACL('delete', 'com_joomgallery.image', $item->id, $item->catid, true);
                   $canChange  = $this->getAcl()->checkACL('editstate', 'com_joomgallery.image', $item->id, $item->catid, true);
-                  $canCheckin = $canChange || $item->checked_out == $this->getUser()->id;
+                  $canCheckin = $canChange || $item->checked_out == $this->getCurrentUser()->id;
                   $disabled   = ($item->checked_out > 0) ? 'disabled' : '';
                 ?>
 


### PR DESCRIPTION
This PR removes all Deprecations which are displayed in a Joomla! installation of version 6.0.0-alpha1-dev. This makes JoomGallery 4 fully Joomla 6 compatible and prepares towards Joomla 7 compatibility.

Only deprecations which are not removed are `triggerEvent`, `setError` and `getError`. We should wait until we know how the Joomla Core is threating this deprecations before we implement our own solutions to keep full Core compatibility also in the future.

### Related Joomla CMS PRs
**Error handling:** https://github.com/joomla/joomla-cms/pull/44098
**Trigger Events:** https://github.com/joomla/joomla-cms/pull/43395

## How to test this PR?
With this PR nothing has changed from a users perspective. Everything should work as before.
Ideal would be to have a test from each system (Joomla 4, Joomla 5, Joomla 6).