### PR TITLE
Increase length of DB column fullpath

### DIFF
--- a/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
@@ -452,12 +452,12 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_nameshields` (
 
 CREATE TABLE IF NOT EXISTS `#__joomgallery_orphans` (
   `id` int(11) NOT NULL auto_increment,
-  `fullpath` varchar(255) NOT NULL,
+  `fullpath` varchar(500) NOT NULL,
   `type` varchar(7) NOT NULL,
   `refid` int(11) NOT NULL,
   `title` text NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `fullpath` (`fullpath`(255))
+  KEY `fullpath` (`fullpath`(500))
 ) DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `#__joomgallery_users` (

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.7.1.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.7.1.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `#__joomgallery_orphans` CHANGE `fullpath` `fullpath` varchar(500) NOT NULL;
-ALTER TABLE `#__joomgallery_orphans` DROP INDEX `fullpath`, ADD INDEX `fullpath` (`fullpath`(500)) USING BTREE;
+ALTER TABLE `#__joomgallery_orphans` DROP INDEX `fullpath`, ADD INDEX `fullpath` (`fullpath`(500));

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.7.1.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.7.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__joomgallery_orphans` CHANGE `fullpath` `fullpath` varchar(500) NOT NULL;
+ALTER TABLE `#__joomgallery_orphans` DROP INDEX `fullpath`, ADD INDEX `fullpath` (`fullpath`(500)) USING BTREE;


### PR DESCRIPTION
If the length of the **entire system path** of a **category** or an **image** exceeds 255 characters, an error occurs in the maintenance manager.
See https://www.forum.joomgalleryfriends.net/forum/index.php?thread/477-vorbereitung-migration-3-7cr1-waisen-die-keine-waisen-sind/
This is due to the restriction of the **fullpath** column in database table **#__joomgallery_orphans** to 255 characters.
This PR extends the column to 500 characters so that no errors occur in the maintenance manager.