### PR TITLE
Raw image output dont show on IIS/Windows

### DIFF
--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -88,17 +88,21 @@ class RawView extends JoomGalleryView
       $this->app->redirect(Route::_('index.php', false), 404);
     }    
 
-    // Set mime encoding
+    // Set mime encoding to document
     $this->getDocument()->setMimeEncoding($file_info->mime_type);
 
     // Set header to specify the file name
+    $this->app->setHeader('Content-Type', $file_info->mime_type);
+    $this->app->setHeader('Content-Disposition','inline; filename='.\basename($img_path));
+    $this->app->setHeader('Content-Length',\strval($file_info->size));
     $this->app->setHeader('Cache-Control','no-cache, must-revalidate');
     $this->app->setHeader('Pragma','no-cache');
-    $this->app->setHeader('Content-disposition','inline; filename='.\basename($img_path));
-    $this->app->setHeader('Content-Length',\strval($file_info->size));
 
-    \ob_end_clean(); //required here or large files will not work
+    // Required for large files to work properly
+    if(\ob_get_level() > 0) \ob_end_clean();
+
     \fpassthru($resource);
+    \fclose($resource);
   }
 
   /**


### PR DESCRIPTION
This PR should fix issue #202 

It optimized the way HTTP headers are set and how the server buffers are cleaned. This should allow also for the more strict Windows environment to show the images correctly.

One further optimisation could be to read the image files into PHP resources using binary-safe reading mode. To apply that yoi have to change the following line in the Joomla! core Plugin:
https://github.com/joomla/joomla-cms/blob/ab8edd172da91abcb094975f5a93690e83e31ca2/plugins/filesystem/local/src/Adapter/LocalAdapter.php#L213

change this line
`return fopen($this->rootPath . '/' . $path, 'r');`

to this line
`return fopen($this->rootPath . '/' . $path, 'rb');`