### PR TITLE
JoomgalleryOwner: PHP notice because of variable references

### DIFF
--- a/plugins/system/joomowner/joomowner.xml
+++ b/plugins/system/joomowner/joomowner.xml
@@ -31,8 +31,8 @@
                     class="validate-numeric"
                     maxlength="5"
                     default=""
-                    label="PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_LABEL"
-                    description="PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_DESC"
+                    label="PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_LABEL"
+                    description="PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_DESC"
                     filter="INT"
                 />
             </fieldset>

--- a/plugins/system/joomowner/language/en-GB/plg_system_joomowner.ini
+++ b/plugins/system/joomowner/language/en-GB/plg_system_joomowner.ini
@@ -3,10 +3,10 @@ PLG_SYSTEM_JOOMOWNER_XML_DESCRIPTION="This plugin ensures that the connections t
 
 PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_LABEL="Fallback user"
 PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_DESC="Select user to be put in place of the deleted user."
-PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_LABEL="Search user ID"
-PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_DESC="The user ID entered here will be searched and replaced by the fallback user."
+PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_LABEL="Search user ID"
+PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_DESC="The user ID entered here will be searched and replaced by the fallback user."
 
-PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
+PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALLY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
 PLG_SYSTEM_JOOMOWNER_ERROR_FALLBACK_USER_CONNECTED_MSG="The user has been set as a fallback and therefore cannot be deleted. <br />Please change before in the <a class=\"alert-link\" href=\"/administrator/index.php?option=com_plugins&view=plugins&filter[element]=joomowner\">plugin settings</a>!"
 PLG_SYSTEM_JOOMOWNER_ERROR_USER_NOT_DELETED_MSG="The user was not deleted!"
 PLG_SYSTEM_JOOMOWNER_USER_DELETED_MSG="For the all JoomGallery %s with IDs '%s', the old user ID '%d' has been replaced with the fallback user ID '%d'."

--- a/plugins/system/joomowner/language/en-GB/plg_system_joomowner.sys.ini
+++ b/plugins/system/joomowner/language/en-GB/plg_system_joomowner.sys.ini
@@ -3,10 +3,10 @@ PLG_SYSTEM_JOOMOWNER_XML_DESCRIPTION="This plugin ensures that the connections t
 
 PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_LABEL="Fallback user"
 PLG_SYSTEM_JOOMOWNER_FALLBACK_USER_DESC="Select user to be put in place of the deleted user."
-PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_LABEL="Search user ID"
-PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALY_DESC="The user ID entered here will be searched and replaced by the fallback user."
+PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_LABEL="Search user ID"
+PLG_SYSTEM_JOOMOWNER_ID_TO_CHANGE_MANUALLY_DESC="The user ID entered here will be searched and replaced by the fallback user."
 
-PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
+PLG_SYSTEM_JOOMOWNER_ERROR_USER_ID_TO_CHANGE_MANUALLY_EXISTS="The user with ID '%d' still exists. Nothing has been changed."
 PLG_SYSTEM_JOOMOWNER_ERROR_FALLBACK_USER_CONNECTED_MSG="The user has been set as a fallback and therefore cannot be deleted. <br />Please change before in the <a class=\"alert-link\" href=\"/administrator/index.php?option=com_plugins&view=plugins&filter[element]=joomowner\">plugin settings</a>!"
 PLG_SYSTEM_JOOMOWNER_ERROR_USER_NOT_DELETED_MSG="The user was not deleted!"
 PLG_SYSTEM_JOOMOWNER_USER_DELETED_MSG="For the all JoomGallery %s with IDs '%s', the old user ID '%d' has been replaced with the fallback user ID '%d'."


### PR DESCRIPTION
This PR should fix issue [#178](https://github.com/JoomGalleryfriends/JoomGallery/issues/178)

Php error in onContentBeforeSave -> '&' in ```[$context, &$table, $isNew, $data] = $event->getArguments();``` not allowed

### Solution:
* Fix/php ref outdated. Ref is not needed as object is given back as refernce (See [Nicholas K. Dionysopoulos: the book (plugins)](https://www.dionysopoulos.me/book/plg.html#plg-forms-j4-subscriberinterface) red section)
* Replaced call for J4x/J5y with common solution. Code also found in above book
* Spelling: manualy -> manually for Variable name and translations but not for field name

### How to test this PR

* User jg1 creates category and uploads images and is deleted then. User jg2  gets the category and images assigned
  -> Result: jg2 owns the category and the images
*  Save configuration, some categories, images ... without error (and with second user) with out error





