### PR TITLE
[Fix] Filesystem during migration

### DIFF
--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -1329,8 +1329,8 @@ class MigrationModel extends JoomAdminModel
       $table->setLocation($data['parent_id'], 'last-child');
     }
 
-    // Create filesystem service
-    $this->component->createFilesystem();
+    // Create filemanager which will create config and filesystem
+    $this->component->createFileManager($data['catid']);
 
     // Set filesystem
     $data['filesystem'] = $this->component->getFilesystem()->get('filesystem');

--- a/administrator/com_joomgallery/src/Model/MigrationModel.php
+++ b/administrator/com_joomgallery/src/Model/MigrationModel.php
@@ -1329,6 +1329,12 @@ class MigrationModel extends JoomAdminModel
       $table->setLocation($data['parent_id'], 'last-child');
     }
 
+    // Create filesystem service
+    $this->component->createFilesystem();
+
+    // Set filesystem
+    $data['filesystem'] = $this->component->getFilesystem()->get('filesystem');
+
     // Bind migrated data to table object
     if(!$table->bind($data))
     {


### PR DESCRIPTION
This PR fixes the issue #204.

The filesystem is now taken from the config service before safing to the database during migration.