### PR TITLE
[Fix] Stabalize FileManager::getImgPath()

### DIFF
--- a/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManager.php
@@ -1181,7 +1181,7 @@ class FileManager implements FileManagerInterface
    * Returns the path to an image
    *
    * @param   object|int|string         $img       Image object, image ID or image alias (new images: ID=0)
-   * @param   string                    $type      Imagetype
+   * @param   string                    $type      Imagetype (default: thumbnail)
    * @param   object|int|string|bool    $catid     Category object, category ID, category alias or category path (default: false)
    * @param   string|bool               $filename  The filename (default: false)
    * @param   boolean                   $root      True to add the system root to the path
@@ -1191,7 +1191,7 @@ class FileManager implements FileManagerInterface
    * 
    * @since   4.0.0
    */
-  public function getImgPath($img, $type, $catid=false, $filename=false, $root=false, $logfile='jerror')
+  public function getImgPath($img, $type='thumbnail', $catid=false, $filename=false, $root=false, $logfile='jerror')
   {
     if($catid === false || $filename === false)
     {
@@ -1250,7 +1250,12 @@ class FileManager implements FileManagerInterface
     }
 
     // Create the path of the image
-    $path = $this->imagetypes[$this->imagetypes_dict[$type]]->path.\DIRECTORY_SEPARATOR.$catpath.\DIRECTORY_SEPARATOR.$filename;
+    $type_path = $this->imagetypes[$this->imagetypes_dict[$type]]->path;
+    if(!$type_path)
+    {
+      $type_path = '/images/joomgallery/thumbnails';
+    }
+    $path = $type_path.\DIRECTORY_SEPARATOR.$catpath.\DIRECTORY_SEPARATOR.$filename;
 
     // add root to path if needed
     if($root)

--- a/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
+++ b/administrator/com_joomgallery/src/Service/FileManager/FileManagerInterface.php
@@ -192,7 +192,7 @@ interface FileManagerInterface
    * Returns the path to an image
    *
    * @param   object|int|string         $img       Image object, image ID or image alias (new images: ID=0)
-   * @param   string                    $type      Imagetype
+   * @param   string                    $type      Imagetype (default: thumbnail)
    * @param   object|int|string|bool    $catid     Category object, category ID, category alias or category path (default: false)
    * @param   string|bool               $filename  The filename (default: false)
    * @param   boolean                   $root      True to add the system root to the path
@@ -202,7 +202,7 @@ interface FileManagerInterface
    * 
    * @since   4.0.0
    */
-  public function getImgPath($img, $type, $catid=false, $filename=false, $root=false, $logfile='jerror');
+  public function getImgPath($img, $type='thumbnail', $catid=false, $filename=false, $root=false, $logfile='jerror');
 
   /**
    * Returns the path to a category without root path.


### PR DESCRIPTION
This issue was recognized by @Spoicy during implementation of the automatic tagging feature.

When calling this method without the $type argument, the returned path does not include the imagetype path.
`$path = $this->component->getFileManager()->getImgPath($img);`

### Before applying this PR

`$path = <JROOT>/<category-path>/<image-filename>`

### After applying this PR

`$path = <JROOT>/<imagetype-path>/<category-path>/<image-filename>`

### How to test this PR
1. Upload an image into the category Uncategorised (catid=2).
2. Check the id of the uploaded image
3. Past the following PHP code into a html view script
4. Display the html view
5. Check that the path exist and points to the image file you just uploaded

```
$imgid = <image-id>

$component = $this->app->bootComponent('com_joomgallery');
$component->createFileManager(2);
$path = $component->getFileManager()->getImgPath($imgid);
var_dump($path);
```

Before applying this PR the path will not be correct. After applying this PR the path will point to the thumbnail image of the uploaded image.