### PR TITLE
[Feature] load more pagination takes over settings

### DIFF
--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -4,6 +4,8 @@ const defaults = {
         pagination: 1,
         layout: 'masonry',
         num_columns: 3,
+        numb_images: 12,
+        reloaded_images: 3,
         lightbox: false,
         thumbnails: false,
         lightbox_obj: {},
@@ -97,9 +99,18 @@ var callback = function() {
     // Infinity scroll or load more
     if(settings.pagination == 1 && grid || settings.pagination == 2 && grid)
     {
+      let maxImages;
+      let loadImages;
+      if(settings.pagination == 1) {
+          maxImages  = settings.num_columns * 2;
+          loadImages = settings.num_columns * 3;
+      }
+      if(settings.pagination == 2) {
+          maxImages  = settings.numb_images;
+          loadImages = settings.reloaded_images;
+      }
+
       const items        = Array.from(grid.getElementsByClassName('jg-image'));
-      const maxImages    = settings.num_columns * 2;
-      const loadImages   = settings.num_columns * 3;
       const hiddenClass  = 'hidden-jg-image';
       const hiddenImages = Array.from(document.getElementsByClassName(hiddenClass));
 
@@ -116,7 +127,7 @@ var callback = function() {
           rootMargin: '200px',
           threshold: 0
         };
-        
+
         function observerCallback(entries, observer) {
           entries.forEach(entry => {
             if (entry.isIntersecting) {
@@ -140,22 +151,24 @@ var callback = function() {
         fadeElms.forEach(el => observer.observe(el));
       } else if(settings.pagination == 2) {
         // Load more button
-        const loadMore = document.getElementById(settings.loadmoreid);
-    
-        loadMore.addEventListener('click', function () {
-          [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
-            item,
-            index
-          ) {
-            if (index < loadImages) {
-              item.classList.remove(hiddenClass);
-            }
-            if (document.querySelectorAll('.' + hiddenClass).length === 0) {
-              loadMore.style.display = 'none';
-              noMore.classList.remove('hidden');
-            }
+        if(document.getElementById(settings.loadmoreid)) {
+          const loadMore = document.getElementById(settings.loadmoreid);
+
+          loadMore.addEventListener('click', function () {
+            [].forEach.call(document.querySelectorAll('.' + hiddenClass), function (
+              item,
+              index
+            ) {
+              if (index < loadImages) {
+                item.classList.remove(hiddenClass);
+              }
+              if (document.querySelectorAll('.' + hiddenClass).length === 0) {
+                loadMore.style.display = 'none';
+                noMore.classList.remove('hidden');
+              }
+            });
           });
-        });
+        }
       }
     }
 

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -102,6 +102,8 @@ $iniJS .= '  itemid: "1-' . $this->item->id . '",';
 $iniJS .= '  pagination: ' . $use_pagination . ',';
 $iniJS .= '  layout: "' . $category_class . '",';
 $iniJS .= '  num_columns: ' . $num_columns . ',';
+$iniJS .= '  numb_images: ' . $numb_images . ',';
+$iniJS .= '  reloaded_images: ' . $reloaded_images . ',';
 $iniJS .= '  lightbox: ' . ($lightbox ? 'true' : 'false') . ',';
 $iniJS .= '  lightbox_params: {container: "lightgallery-1-'.$this->item->id.'", selector: ".lightgallery-item"},';
 $iniJS .= '  thumbnails: ' . ($thumbnails ? 'true' : 'false') . ',';
@@ -253,7 +255,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
     <div class="infinite-scroll"></div>
     <div id="noMore" class="btn btn-outline-primary no-more-images hidden"><?php echo Text::_('COM_JOOMGALLERY_NO_MORE_IMAGES') ?></div>
   </div>
-  <?php elseif($use_pagination == 2) : ?>
+  <?php elseif($use_pagination == 2 && count($this->item->images->items) > $numb_images) : ?>
     <div class="load-more-container">
       <div id="loadMore" class="btn btn-outline-primary load-more"><span><?php echo Text::_('COM_JOOMGALLERY_LOAD_MORE') ?></span><i class="jg-icon-expand-more"></i></div>
       <div id="noMore" class="btn btn-outline-primary no-more-images hidden"><?php echo Text::_('COM_JOOMGALLERY_NO_MORE_IMAGES') ?></div>


### PR DESCRIPTION
This pull request allows you to set the number of images displayed and the number of images to be reloaded in the settings. The two fields # Images and # Images Reloaded were previously ignored. In addition, the load more button is only displayed if the total number of images exceeds the value of # images.