### PR TITLE
Add upmerge docs

### DIFF
--- a/docs/Upmerge.md
+++ b/docs/Upmerge.md
@@ -1,0 +1,79 @@
+# Upmerge: Änderungen von `master` nach `4.x.0` übernehmen
+Letzte Änderungen: 10.06.2025
+[Change to the english version](Upmerge_en.md)
+
+Dieses Dokument beschreibt, wie ein Contributor oder Maintainer einen **Upmerge von `master` in einen MINOR-Release Branch `v4.x.0`** durchführt – über einen Pull Request aus dem eigenen Fork (origin) in das zentrale Repository (upstream).
+
+> Hinweis: Dieses Vorgehen verwendet **kein zusätzliches temporäres Merge-Branching**, sondern basiert direkt auf dem MINOR-Release Branch.
+
+Für diese Anleitung wird beispielhaft der MINOR-Release Branch `v4.1.0` verwendet.
+
+---
+
+## Ziel
+
+- Änderungen (z. B. Bugfixes) aus `master` sollen auch im MINOR-Release Branch verfügbar sein.
+- Der Merge erfolgt über einen PR von `origin/v4.1.0` nach `upstream/v4.1.0`.
+- Keine direkten Pushes auf `upstream`.
+
+---
+
+## Schritte
+
+### 1. Branch `v4.1.0` lokal erstellen falls nicht vorhanden (basiert auf `upstream/v4.1.0`)
+```bash
+git fetch upstream
+git checkout -b v4.1.0 upstream/v4.1.0
+```
+
+### 2. Branch in den eigenen Fork (origin) pushen
+```bash
+git push origin v4.1.0
+```
+
+### 3. Upmerge von `upstream/master` in den lokalen Branch
+```bash
+git merge upstream/master
+```
+
+### 4. Konflikte lösen (falls nötig) und änderungen commiten
+```bash
+git add *
+git commit -m "upmerge <YYYY-MM-DD>"
+```
+
+### 5. Merge-Änderungen in den Fork pushen
+```bash
+git push origin v4.1.0
+```
+
+---
+
+## 6. Pull Request erstellen
+
+Auf GitHub öffnest du einen neuen Pull Request:
+
+- **Base:** `upstream/v4.1.0`
+- **Compare:** `origin/v4.1.0`
+- **Titel:** `[Chore] Upmerge master into v4.1.0`
+- **Beschreibung:** Optional – z. B. "Merged latest bugfixes from master into v4.1.0"
+
+---
+
+## Hinweise
+
+- Upmerges regelmäßig durchführen, z. B. nach jedem relevanten `master`-Bugfix.
+- Vor Merge sicherstellen, dass beide branches aktualisiert sind:
+  ```bash
+  git pull upstream/v4.1.0
+  git pull upstream/master
+  ```
+
+---
+
+## Vorteile
+
+- ✅ Kein temporärer Merge-Branch notwendig
+- ✅ Sicherer Merge über PR statt Direkt-Push
+- ✅ Volle CI-Unterstützung & Review-Prozess
+- ✅ Reproduzierbar & teamfreundlich

--- a/docs/Upmerge_en.md
+++ b/docs/Upmerge_en.md
@@ -1,0 +1,79 @@
+# Upmerge: Integrating Changes from `master` into `v4.x.0`  
+Last updated: 10.06.2025  
+[Switch to the German version](Upmerge.md)
+
+This document describes how a contributor or maintainer performs an **upmerge from `master` into a MINOR release branch `v4.x.0`** – via a pull request from their own fork (`origin`) into the main repository (`upstream`).
+
+> Note: This approach **does not require a separate temporary merge branch** – it works directly on the MINOR release branch.
+
+This guide uses the MINOR release branch `v4.1.0` as an example.
+
+---
+
+## Objective
+
+- Changes (e.g. bug fixes) from `master` should also be available in the MINOR release branch.
+- The merge is done via a pull request from `origin/v4.1.0` into `upstream/v4.1.0`.
+- No direct pushes to `upstream`.
+
+---
+
+## Steps
+
+### 1. Create the `v4.1.0` branch locally if it does not exist (based on `upstream/v4.1.0`)
+```bash
+git fetch upstream
+git checkout -b v4.1.0 upstream/v4.1.0
+```
+
+### 2. Push the branch to your own fork (`origin`)
+```bash
+git push origin v4.1.0
+```
+
+### 3. Merge changes from `upstream/master` into your local branch
+```bash
+git merge upstream/master
+```
+
+### 4. Resolve any conflicts (if necessary) and commit the changes
+```bash
+git add *
+git commit -m "upmerge <YYYY-MM-DD>"
+```
+
+### 5. Push the upmerged branch to your fork
+```bash
+git push origin v4.1.0
+```
+
+---
+
+## 6. Create a Pull Request
+
+Open a new pull request on GitHub:
+
+- **Base:** `upstream/v4.1.0`
+- **Compare:** `origin/v4.1.0`
+- **Title:** `[Chore] Upmerge master into v4.1.0`
+- **Description:** Optional – e.g. "Merged latest bug fixes from master into v4.1.0"
+
+---
+
+## Notes
+
+- Perform upmerges regularly, e.g. after each relevant bug fix in `master`.
+- Before merging, ensure both branches are up to date:
+  ```bash
+  git pull upstream/v4.1.0
+  git pull upstream/master
+  ```
+  
+---
+
+## Benefits
+
+- ✅ No need for a temporary merge branch
+- ✅ Safe merging via pull request instead of direct pushes
+- ✅ Full support for CI and code review
+- ✅ Reproducible and team-friendly process


### PR DESCRIPTION
This PR adds documentation on how to perform an upmerge from the master branch to a MINOR-Release Branch (e.g v4.1.0).