### PR TITLE
[Bugfix] Pagination number remembered through different categories

### DIFF
--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -472,12 +472,12 @@ class CategoryModel extends JoomItemModel
     }
 
     $imgform_list = array();
-    $imgform_limitstart = $this->app->getUserState('joom.categoryview.image.limitstart', 0);
+    $imgform_limitstart = $this->app->getUserState('joom.categoryview.'.$this->item->id.'.image.limitstart', 0);
     if($this->app->input->get('contenttype', '') == 'image')
     {
       // Get query variables sent by the images form
       $imgform_list = $this->app->input->get('list', array());
-      $imgform_limitstart = $this->app->getUserStateFromRequest('joom.categoryview.image.limitstart', 'limitstart', 0, 'uint');
+      $imgform_limitstart = $this->app->getUserStateFromRequest('joom.categoryview.'.$this->item->id.'.image.limitstart', 'limitstart', 0, 'uint');
     }
 
     // Override number of images being loaded
@@ -542,12 +542,12 @@ class CategoryModel extends JoomItemModel
     }
 
     $catform_list = array();
-    $catform_limitstart = $this->app->getUserState('joom.categoryview.category.limitstart', 0);
+    $catform_limitstart = $this->app->getUserState('joom.categoryview.'.$this->item->id.'.category.limitstart', 0);
     if($this->app->input->get('contenttype', '') == 'category')
     {
       // Get query variables sent by the subcategories form
       $catform_list = $this->app->input->get('list', array());
-      $catform_limitstart = $this->app->getUserStateFromRequest('joom.categoryview.category.limitstart', 'limitstart', 0, 'uint');
+      $catform_limitstart = $this->app->getUserStateFromRequest('joom.categoryview.'.$this->item->id.'.category.limitstart', 'limitstart', 0, 'uint');
     }
 
     // Override number of subcategories being loaded

--- a/site/com_joomgallery/src/Model/GalleryModel.php
+++ b/site/com_joomgallery/src/Model/GalleryModel.php
@@ -201,7 +201,7 @@ class GalleryModel extends JoomItemModel
     {
       // Get query variables sent by the images form
       $imgform_list = $this->app->input->get('list', array());
-      $imgform_limitstart = $this->app->getInput()->get('limitstart', 0, 'int');
+      $imgform_limitstart = $this->app->getUserStateFromRequest('joom.galleryview.limitstart', 'limitstart', 0, 'uint');
     }
 
     // Load the number of images defined in the configuration


### PR DESCRIPTION
This PR fixes issue reported in #184.

Before applying this PR, the current page number is remembered over different categories. Now the page is remembered for each category seperately.

### How to test this PR
Create two categories and upload about 10 images each. Adjust the setting `# Images` in `Frontend Views/Category View/Category Images` to a low number such that it results in at least two pages in the frontend.

Visit the categories in the frontend. The current page number should be remembered seperately for each category.