### PR TITLE
[Bugfix] Dynamic image processing with PNG files

### DIFF
--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -257,7 +257,15 @@ abstract class IMGtools implements IMGtoolsInterface
     if($this->src_type == 'PNG')
     {
       // Detect if png is based on palettes
-      $included = \strpos(\file_get_contents($img), "PLTE");
+      if($is_stream)
+      {
+        $included = \strpos($string_stream, "PLTE");
+      }
+      else
+      {
+        $included = \strpos(\file_get_contents($img), "PLTE");
+      }
+
       if($included !== false)
       {
         $this->res_imginfo['truecolor'] = false;

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -453,11 +453,11 @@ class IMtools extends BaseIMGtools implements IMGtoolsInterface
 
     // Temporary remove '[0]' from src_file
     $first_frame_only = false;
-    if(\strpos($this->src_file, '[0]') !== false)
+    if(\is_string($this->src_file) && \strpos($this->src_file, '[0]') !== false)
     {
       $this->src_file = \str_replace('[0]','',$this->src_file);
       $first_frame_only = true;
-    }    
+    }
 
     // Define temporary image file to be created
     $tmp_folder   = $this->app->get('tmp_path');


### PR DESCRIPTION
This PR fixes issue reported in #213.

Before applying this PR, PNG files could not be dynamically processed. The image request failed as there was the PHP error `file_get_contents(): Argument #1 ($filename) must be of type string, resource given`. This is now fixed. Dynamic processing of PNG files works again.

### How to test this PR
1. Upload a PNG file to JoomGallery.
2. Activate and apply image processing to the detail image in the JG configurations: `General Settings/Image Processing/Image processing (dynamic images)`
3. Visit the detail view of the uploaded PNG image
4. Image should be shown and no PHP error appearing.

**Unrelated second issue**
During testing I discovered that watermarking of a transparent PNG image using the GD image processor is not possible. The created image looses transparency.