### PR TITLE
Upload view: Display upload limits to the user in upload view

### DIFF
--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -13,6 +13,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 defined('_JEXEC') or die;
 
 use \Joomla\CMS\Factory;
+use \Joomla\CMS\Helper\MediaHelper;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Toolbar\Toolbar;
 use \Joomla\CMS\Toolbar\ToolbarHelper;
@@ -32,7 +33,13 @@ class HtmlView extends JoomGalleryView
   protected $config;
   protected $imagetypes;
 
-	/**
+  protected $uploadLimit;
+  protected $postMaxSize;
+  protected $memoryLimit;
+  protected $maxSize;
+  protected $configSize;
+
+  /**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  Template name
@@ -81,6 +88,20 @@ class HtmlView extends JoomGalleryView
       $js_vars->semaTokens   = 100;                                           // Prealloc space for 100 tokens
 
       $this->js_vars = $js_vars;
+
+      //--- Limits --------------------------------------------------------------------
+
+      $mediaHelper = new MediaHelper;
+
+      // Maximum allowed size in MB
+      $this->uploadLimit = round($mediaHelper->toBytes(ini_get('upload_max_filesize')) / (1024 * 1024));
+      $this->postMaxSize = round($mediaHelper->toBytes(ini_get('post_max_size')) / (1024 * 1024));
+      $this->memoryLimit = round($mediaHelper->toBytes(ini_get('memory_limit')) / (1024 * 1024));
+
+      $this->configSize = round($this->config->get('jg_maxfilesize') / (1024 * 1024));
+
+      // Max size calculated (previously defined by joomla function)
+      $this->maxSize = min($this->uploadLimit, $this->postMaxSize, $this->memoryLimit, $this->configSize);
     }
     elseif($this->_layout == 'replace')
     {

--- a/administrator/com_joomgallery/tmpl/image/upload.php
+++ b/administrator/com_joomgallery/tmpl/image/upload.php
@@ -74,6 +74,9 @@ $wa->addInlineScript('window.uppyVars = JSON.parse(\''. json_encode($this->js_va
           <div class="card-body">
             <?php echo $this->form->renderField('debug'); ?>
           </div>
+          <div>
+            <?php DisplaySystemSettings($this->uploadLimit, $this->postMaxSize, $this->memoryLimit, $this->configSize, $this->maxSize); ?>
+          </div>
         </div>
       </div>
       <div class="col card">
@@ -123,3 +126,86 @@ $wa->addInlineScript('window.uppyVars = JSON.parse(\''. json_encode($this->js_va
   </form>
   <div id="popup-area"></div>
 </div>
+
+<?php
+/**
+ * Display system settings as collapsed
+ *
+ * Parameter: limits in megabytes, created in viewhtml.php
+ * @param   int  $UploadLimit  php setting 'upload_max_filesize'
+ * @param   int  $PostMaxSize  php setting 'post_max_size'
+ * @param   int  $MemoryLimit  php setting 'memory_limit'
+ * @param   int  $configSize   upload limit by joomgallery configuraion
+ * @param   int  $maxSize      Min of above
+ *
+ * @since 4.1.0
+ */
+function DisplaySystemSettings($UploadLimit, $PostMaxSize, $MemoryLimit, $configSize, $maxSize)
+{
+  $title  = Text::sprintf('COM_JOOMGALLERY_POST_MAX_SIZE_IS', $maxSize);
+  $id     = 127000;
+  $itemId = 127001;
+  ?>
+
+  <div class="card">
+    <div class="accordion" id="<?php echo $id; ?>">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="<?php echo $itemId; ?>Header">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                  data-bs-target="#<?php echo $itemId; ?>" aria-expanded="false" aria-controls="<?php echo $itemId; ?>">
+            <?php echo Text::_($title); ?>
+          </button>
+        </h2>
+        <div id="<?php echo $itemId; ?>" class="accordion-collapse collapse"
+             aria-labelledby="<?php echo $itemId; ?>Header" data-bs-parent="#<?php echo $id; ?>">
+          <div class="accordion-body">
+            <table class="table table-striped">
+              <thead>
+                <tr>&nbsp;</tr>
+                <tr>&nbsp;</tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="d-md-table-cell">
+                    <?php echo Text::sprintf('COM_JOOMGALLERY_UPLOAD_UPLOAD_LIMIT_IS', $UploadLimit); ?>
+                  </td>
+                  <td class="d-md-table-cell">
+                    <strong><?php echo $UploadLimit; ?></strong>&nbsp;MB ('upload_max_filesize')"
+                  </td>
+                </tr>
+                <tr>
+                  <td class="d-md-table-cell">
+                    <?php echo Text::sprintf('COM_JOOMGALLERY_UPLOAD_POST_MAX_SIZE_IS', $PostMaxSize); ?>
+                  </td>
+                  <td class="d-md-table-cell">
+                    <strong><?php echo $PostMaxSize; ?></strong>&nbsp;MB ('post_max_size')
+                  </td>
+                </tr>
+                <tr>
+                  <td class="d-md-table-cell">
+                    <?php echo Text::sprintf('COM_JOOMGALLERY_UPLOAD_POST_MEMORY_LIMIT_IS', $MemoryLimit); ?>
+                  </td>
+                  <td class="d-md-table-cell">
+                    <strong><?php echo $MemoryLimit; ?></strong>&nbsp;MB ('memory_limit')
+                  </td>
+                </tr>
+                <tr>
+                  <td class="d-md-table-cell">
+                    <?php echo Text::sprintf('COM_JOOMGALLERY_UPLOAD_CONFIG_LIMIT_IS', $configSize); ?>
+                  </td>
+                  <td class="d-md-table-cell">
+                    <strong><?php echo $configSize; ?></strong>&nbsp;MB
+                  </td>
+                </tr>
+
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <?php return;
+}
+?>


### PR DESCRIPTION
Intention: Tell the user which upload limit is active in the upload form where he may need it.

The user sees one line with a calculated maximum upload limit. It is calculated from the minum of the other variables shown when opening the aditional lines.
The limits are defined in php.ini and joomgalley config. See description behind the values.

![Limits by php.ini and config](https://github.com/ThomasFinnern/JoomGallery_fith_dev/blob/main/.jg_dev_doc/jg_4x/images/site.UserUpload/userUpload.maxlimit.en.png?raw=true  "")

How to test: 

1) It should display, and open all lines on click 
2) Check values in php.ini and config for matching 
3) Change values there when two lines have the same to be sure it adresses the right vaiable




