### PR TITLE
remove the hidden class from the common settings

### DIFF
--- a/administrator/com_joomgallery/forms/config.xml
+++ b/administrator/com_joomgallery/forms/config.xml
@@ -458,7 +458,6 @@
               validate="number"
               filter="integer"
               showon="jg_userspace:1"
-              class="hidden"
               label="COM_JOOMGALLERY_CONFIG_MAX_USERCATS"
               description="COM_JOOMGALLERY_CONFIG_MAX_USERCATS_LONG" />
 
@@ -470,7 +469,6 @@
               validate="number"
               filter="integer"
               showon="jg_userspace:1"
-              class="hidden"
               label="COM_JOOMGALLERY_CONFIG_MAX_USERIMGS"
               description="COM_JOOMGALLERY_CONFIG_MAX_USERIMGS_LONG" />
 
@@ -482,7 +480,6 @@
               filter="integer"
               default="0"
               showon="jg_userspace:1"
-              class="hidden"
               label="COM_JOOMGALLERY_CONFIG_MAX_USERIMGS_TIMESPAN"
               description="COM_JOOMGALLERY_CONFIG_MAX_USERIMGS_TIMESPAN_LONG" />
 
@@ -494,7 +491,6 @@
               validate="number"
               filter="integer"
               showon="jg_userspace:1"
-              class="hidden"
               label="COM_JOOMGALLERY_CONFIG_MAX_FILESIZE"
               description="COM_JOOMGALLERY_CONFIG_MAX_FILESIZE_LONG" />
     </fieldset>


### PR DESCRIPTION
For the upcoming pull request (user_panel_upload) from Thomas, it is necessary to remove this class from the four configuration options in order to be able to edit the values.

Global Configration » User Settings » Common Settings



<img width="1026" alt="Common-Settings" src="https://github.com/user-attachments/assets/52fa83c6-478e-433f-b8a4-4d56bc1795f8" />
