### PR TITLE
Fix update issue in Joomla! < v5.1

### DIFF
--- a/script.php
+++ b/script.php
@@ -339,9 +339,12 @@ class com_joomgalleryInstallerScript extends InstallerScript
                      'width'      => '800px',
                      'height'     => 'fit-content',
                     ];
-    /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-    $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-    $wa->useScript('joomla.dialog-autocreate');
+    if(version_compare(JVERSION, '5.1.0', '>'))
+    {
+      /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+      $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+      $wa->useScript('joomla.dialog-autocreate');
+    }
     ?>
 
     <div class="text-center">


### PR DESCRIPTION
One of the PRs added to JoomGallery v4.1.0 which added a working changelog button, created an issue in Joomla! versions older than v5.1.0.

PR which added the changelog button:
[#235](https://github.com/JoomGalleryfriends/JoomGallery/pull/235)

PR which changed the way how to create bootstrap modal boxes in Joomla!:
https://github.com/joomla/joomla-cms/pull/42447

So the code introduced in #235 creates an error in the update script when perfomed in Joomla! versions before v5.1.0

This PR fixes this issue.

### How to test this PR
Install JoomGallery v4.0.1 on a Joomla! version v5.0.3 or older.
Than install this PR. The component should be updated successfully.