### PR TITLE
Improve zip creation script

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,6 +28,11 @@ jobs:
         run: |
           rm -rf crowdin.yml composer.json composer.lock docs tests .github .editorconfig
 
+      - name: Cleanup pel directory
+        run: |
+          PEL_DIR="administrator/com_joomgallery/vendor/fileeye/pel"
+          find "$PEL_DIR" -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'autoload.php' ! -name 'composer.json' -exec rm -rf {} +
+
       - name: Sanitize PR title for filename
         id: pr
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           rm -rf crowdin.yml composer.json composer.lock docs tests .github .editorconfig
 
+      - name: Cleanup pel directory
+        run: |
+          PEL_DIR="administrator/com_joomgallery/vendor/fileeye/pel"
+          find "$PEL_DIR" -mindepth 1 -maxdepth 1 ! -name 'src' ! -name 'autoload.php' ! -name 'composer.json' -exec rm -rf {} +
+
       - name: Get tag name
         id: get_tag
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR improved the script which is run by GitHub on a PR or on a release to create an installable zip file containing all 3rd party libraries.
The improvement mainly exists on cleaning up the installed repository folder of the pel library by deleteing everything which is not really needed for running the code.

## Before this PR
The zip file created has a size of about 4,6 MB

## After this PR
The zip file created has a size of about 1,5 MB

## How to test this PR
The zip created by the script (artifact) should be installable and everything should still work.