### PR TITLE
[Fix] Allow multiple justified grids

### DIFF
--- a/media/com_joomgallery/js/joomgrid.js
+++ b/media/com_joomgallery/js/joomgrid.js
@@ -40,7 +40,7 @@ var callback = function() {
     }
 
     // Get the grid container
-    const grid = document.querySelector('.' + settings.gridclass);
+    const grid = document.getElementById(settings.lightbox_params.container);
 
     // Initialize lightGallery
     if(settings.lightbox) {


### PR DESCRIPTION
This PR fixes the issue that multiple justified grids are displayed correctly.

Before this PR, only one justified grid was diapleyed correctly. Every other justified grids have their images one below the other. one line per image.

### How to test this PR
Install the PR and a content plugin allowing multiple image grids display. Add at least two category grids into one article and choose the layout `justified`. With this PR applied, all category grids should be displayed correctly.