### PR TITLE
[Fix] Remove forgotten J6 deprecations

### DIFF
--- a/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
+++ b/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
@@ -61,7 +61,6 @@ class JoomgalleryComponent extends MVCComponent implements BootableExtensionInte
   use MessageTrait;
 	use AssociationServiceTrait;
 	use HTMLRegistryAwareTrait;
-  // use RouterServiceTrait;
   use RouterServiceTrait {RouterServiceTrait::createRouter as traitCreateRouter;}
 
   /**

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -1243,4 +1243,31 @@ class JoomHelper
     // Default rule: add 's'
     return $word . 's';
   }
+
+  /**
+   * Returns a Table Object
+   *
+   * @param   string    $tableClass   The name of the table (e.g '\\Joomla\\CMS\\Table\\Module')
+   *
+   * @return  object|bool   Table object on success, false otherwise.
+   *
+   * @since   4.2.0
+   * NOTE:    Use Factory::getApplication()->bootComponent('...')->getMVCFactory()->createTable($name, $prefix, $config); instead
+   */
+  public static function getTableInstance(string $tableClass)
+  {
+    if(!\class_exists($tableClass))
+    {
+      return false;
+    }
+
+    // Check for a possible service from the container otherwise manually instantiate the class
+    if(Factory::getContainer()->has($tableClass))
+    {
+      return Factory::getContainer()->get($tableClass);
+    }
+    
+    // Instantiate a new table class and return it.
+    return new $tableClass(Factory::getContainer()->get(DatabaseInterface::class));
+  }
 }

--- a/administrator/com_joomgallery/src/Service/Config/ConfigInterface.php
+++ b/administrator/com_joomgallery/src/Service/Config/ConfigInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Config;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * Interface for the configuration classes

--- a/administrator/com_joomgallery/src/Service/Config/ConfigServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Config/ConfigServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Config;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * The Config service

--- a/administrator/com_joomgallery/src/Service/Config/ConfigServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Config/ConfigServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Config;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Config\DefaultConfig;
 use \Joomla\CMS\Component\ComponentHelper;

--- a/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * The Filesystem service

--- a/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/FilesystemServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem\Filesystem;
 

--- a/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
@@ -14,8 +14,9 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\User\UserFactoryInterface;
 use \Joomla\CMS\Mail\MailTemplate;
+use \Joomla\Database\DatabaseInterface;
+use \Joomla\CMS\User\UserFactoryInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Messenger\Messenger;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Messenger\MessengerInterface;
 

--- a/administrator/com_joomgallery/src/Service/Refresher/RefresherInterface.php
+++ b/administrator/com_joomgallery/src/Service/Refresher/RefresherInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Refresher;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 
 /**

--- a/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Refresher;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * The Refresher service

--- a/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Refresher/RefresherServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Refresher;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Refresher\Refresher;
 

--- a/administrator/com_joomgallery/src/Service/Uploader/HTMLUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/HTMLUploader.php
@@ -13,8 +13,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File as JFile;
-use \Joomla\CMS\Filesystem\Path as JPath;
+use \Joomla\Filesystem\File as JFile;
+use \Joomla\Filesystem\Path as JPath;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\Uploader as BaseUploader;

--- a/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/SingleUploader.php
@@ -13,8 +13,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File as JFile;
-use \Joomla\CMS\Filesystem\Path as JPath;
+use \Joomla\Filesystem\File as JFile;
+use \Joomla\Filesystem\Path as JPath;
 use \Joomgallery\Component\Joomgallery\Administrator\Table\ImageTable;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\Uploader as BaseUploader;

--- a/administrator/com_joomgallery/src/Service/Uploader/TUSUploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/TUSUploader.php
@@ -13,8 +13,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File as JFile;
-use \Joomla\CMS\Filesystem\Path as JPath;
+use \Joomla\Filesystem\File as JFile;
+use \Joomla\Filesystem\Path as JPath;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\Uploader as BaseUploader;

--- a/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
@@ -16,6 +16,7 @@ use \Joomla\CMS\Language\Text;
 use \Joomla\Filesystem\File as JFile;
 use \Joomla\CMS\Filter\InputFilter;
 use \Joomla\CMS\Filter\OutputFilter;
+use \Joomla\Database\DatabaseInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 

--- a/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
@@ -13,12 +13,9 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Language\Text;
-use \Joomla\CMS\Filesystem\File as JFile;
-use \Joomla\CMS\Filesystem\Path as JPath;
+use \Joomla\Filesystem\File as JFile;
 use \Joomla\CMS\Filter\InputFilter;
 use \Joomla\CMS\Filter\OutputFilter;
-use \Joomla\CMS\Object\CMSObject;
-
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\UploaderInterface;
 use \Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 
@@ -264,7 +261,7 @@ abstract class Uploader implements UploaderInterface
     require_once JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION.'/includes/iptcarray.php';
     require_once JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION.'/includes/exifarray.php';
 
-    $lang = Factory::getLanguage();
+    $lang = $this->app->getLanguage();
     $lang->load(_JOOM_OPTION.'.exif', JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION);
     $lang->load(_JOOM_OPTION.'.iptc', JPATH_ADMINISTRATOR.'/components/'._JOOM_OPTION);
 
@@ -418,7 +415,7 @@ abstract class Uploader implements UploaderInterface
         $data['title'] = $filter->clean($source_value, 'string');
 
         // Recreate alias
-        if(Factory::getConfig()->get('unicodeslugs') == 1)
+        if($this->app->getConfig()->get('unicodeslugs') == 1)
         {
           $data['alias'] = OutputFilter::stringURLUnicodeSlug(trim($data['title']));
         }
@@ -500,7 +497,7 @@ abstract class Uploader implements UploaderInterface
       $this->component->createMessenger($jg_filenamenumber);
 
       // Get user
-      $user = Factory::getUser();
+      $user = $this->app->getIdentity();
 
       // Get category
       $cat = JoomHelper::getRecord('category', $data_row->catid, $this->component);
@@ -541,7 +538,7 @@ abstract class Uploader implements UploaderInterface
   /**
    * Rollback an erroneous upload
    *
-   * @param   CMSObject   $data_row     Image object containing at least catid and filename (default: false)
+   * @param   object  $data_row   Image object containing at least catid and filename (default: false)
    *
    * @return  void
    *
@@ -599,7 +596,7 @@ abstract class Uploader implements UploaderInterface
    */
   protected function getImageNumber($userid)
   {
-    $db = Factory::getDbo();
+    $db = Factory::getContainer()->get(DatabaseInterface::class);
 
     $query = $db->getQuery(true)
           ->select('COUNT(id)')
@@ -679,7 +676,7 @@ abstract class Uploader implements UploaderInterface
    *
    * @param   array   $data      The form data
    *
-   * @return  CMSObject
+   * @return  object
    *
    * @since   4.0.0
    */
@@ -691,10 +688,10 @@ abstract class Uploader implements UploaderInterface
       throw new \Exception('Form data must have at least catid and filename');
     }
 
-    $img = new CMSObject;
+    $img = new stdClass;
 
-    $img->set('catid', $data['catid']);
-    $img->set('filename', $data['filename']);
+    $img->catid = $data['catid'];
+    $img->filename = $data['filename'];
 
     return $img;
   }

--- a/administrator/com_joomgallery/src/Service/Uploader/UploaderInterface.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/UploaderInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Table\ImageTable;
 

--- a/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceInterface.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceInterface.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 /**
 * The Uploader service

--- a/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/UploaderServiceTrait.php
@@ -9,7 +9,7 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Uploader;
 
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\HTMLUploader;
 use \Joomgallery\Component\Joomgallery\Administrator\Service\Uploader\TUSUploader;

--- a/script.php
+++ b/script.php
@@ -991,6 +991,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
       $pluginGroup = (string) $plugin['group'];
       $path        = $installation_folder . '/plugins/' . $pluginGroup . '/' . $pluginName;
       $installer   = new Installer;
+      $installer->setDatabase($db);
 
       if (!$this->isAlreadyInstalled('plugin', $pluginName, $pluginGroup))
       {
@@ -1062,8 +1063,9 @@ class com_joomgalleryInstallerScript extends InstallerScript
 	 */
 	private function installModules($parent)
 	{
-		$installation_folder = $parent->getParent()->getPath('source');
-		$app                 = Factory::getApplication();
+		$folder = $parent->getParent()->getPath('source');
+		$app    = Factory::getApplication();
+		$db     = Factory::getContainer()->get(DatabaseInterface::class);
 
 		if (method_exists($parent, 'getManifest'))
 		{
@@ -1082,8 +1084,9 @@ class com_joomgalleryInstallerScript extends InstallerScript
     foreach($modules->children() as $module)
     {
       $moduleName = (string) $module['module'];
-      $path       = $installation_folder . '/modules/' . $moduleName;
+      $path       = $folder . '/modules/' . $moduleName;
       $installer  = new Installer;
+      $installer->setDatabase($db);
 
       if (!$this->isAlreadyInstalled('module', $moduleName))
       {
@@ -1167,6 +1170,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
       if (!empty($extension))
       {
         $installer = new Installer;
+        $installer->setDatabase($db);
         $result    = $installer->uninstall('plugin', $extension);
 
         if ($result)
@@ -1248,6 +1252,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
       if (!empty($extension))
       {
         $installer = new Installer;
+        $installer->setDatabase($db);
         $result    = $installer->uninstall('module', $extension);
 
         if ($result)

--- a/script.php
+++ b/script.php
@@ -1559,7 +1559,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     // create module if it is not yet created
     if (empty($module_id))
     {
-      $row            = Factory::getApplication()->bootComponent('com_modules')->getMVCFactory()->createTable('module');
+      $row            = $this->getTableInstance('\\Joomla\\CMS\\Table\\Module');
       $row->title     = $title;
       $row->ordering  = $ordering;
       $row->position  = $position;
@@ -1593,5 +1593,32 @@ class com_joomgalleryInstallerScript extends InstallerScript
     }
 
     return true;
+  }
+
+  /**
+   * Returns a Table Object
+   *
+   * @param   string    $tableClass   The name of the table (e.g '\\Joomla\\CMS\\Table\\Module')
+   *
+   * @return  object|bool   Table object on success, false otherwise.
+   *
+   * @since   4.2.0
+   * NOTE:    Use Factory::getApplication()->bootComponent('...')->getMVCFactory()->createTable($name, $prefix, $config); instead
+   */
+  private static function getTableInstance(string $tableClass)
+  {
+    if(!\class_exists($tableClass))
+    {
+      return false;
+    }
+
+    // Check for a possible service from the container otherwise manually instantiate the class
+    if(Factory::getContainer()->has($tableClass))
+    {
+      return Factory::getContainer()->get($tableClass);
+    }
+    
+    // Instantiate a new table class and return it.
+    return new $tableClass(Factory::getContainer()->get(DatabaseInterface::class));
   }
 }

--- a/script.php
+++ b/script.php
@@ -15,8 +15,8 @@ use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Table\Table;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Router\Route;
-use \Joomla\CMS\Filesystem\File;
-use \Joomla\CMS\Filesystem\Folder;
+use \Joomla\Filesystem\File;
+use \Joomla\Filesystem\Folder;
 use \Joomla\CMS\Installer\Installer;
 use \Joomla\CMS\Installer\InstallerScript;
 use \Joomla\Database\DatabaseInterface;
@@ -155,7 +155,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     {
       // save release code information
       //-------------------------------
-      if(File::exists(JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'joomgallery.xml'))
+      if(is_file(JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'joomgallery.xml'))
       {
         $xml = simplexml_load_file(JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR.'joomgallery.xml');
         $this->act_code = $xml->version;
@@ -190,7 +190,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
       // copy old XML file (JGv1-3) to temp folder
       $xml_path   = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR;
       $tmp_folder = Factory::getApplication()->get('tmp_path');
-      if(File::exists($xml_path.'joomgallery.xml'))
+      if(is_file($xml_path.'joomgallery.xml'))
       {
         File::copy($xml_path.'joomgallery.xml', $tmp_folder.DIRECTORY_SEPARATOR.'joomgallery_old.xml');
       }
@@ -198,16 +198,16 @@ class com_joomgalleryInstallerScript extends InstallerScript
       // remove old JoomGallery files and folders
       foreach($this->detectJGfolders() as $folder)
       {
-        if(Folder::exists($folder))
+        if(is_dir(Path::clean($folder)))
         {
-          Folder::delete($folder);
+          Folder::delete(Path::clean($folder));
         }
       }
       foreach($this->detectJGfiles() as $file)
       {
-        if(File::exists($file))
+        if(is_file(Path::clean($file)))
         {
-          File::delete($file);
+          File::delete(Path::clean($file));
         }
       }
 
@@ -441,7 +441,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
         // copy old XML file (JGv1-3) back from temp folder
         $xml_path   = JPATH_ADMINISTRATOR.DIRECTORY_SEPARATOR.'components'.DIRECTORY_SEPARATOR.'com_joomgallery'.DIRECTORY_SEPARATOR;
         $tmp_folder = Factory::getApplication()->get('tmp_path');
-        if(File::exists($tmp_folder.DIRECTORY_SEPARATOR.'joomgallery_old.xml'))
+        if(is_file($tmp_folder.DIRECTORY_SEPARATOR.'joomgallery_old.xml'))
         {
           File::copy($tmp_folder.DIRECTORY_SEPARATOR.'joomgallery_old.xml', $xml_path.'joomgallery_old.xml');
         }
@@ -1278,9 +1278,9 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $error = false;
 
     // Create destination folder if not exists
-    if(!Folder::exists($dst))
+    if(!is_dir(Path::clean($dst)))
     {
-      Folder::create($dst);
+      Folder::create(Path::clean($dst));
     }
 
     // Copy files

--- a/script.php
+++ b/script.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die();
 use \Joomla\CMS\Factory;
 use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Log\Log;
-use \Joomla\CMS\Table\Table;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Router\Route;
 use \Joomla\Filesystem\File;
@@ -1559,7 +1558,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     // create module if it is not yet created
     if (empty($module_id))
     {
-      $row            = Table::getInstance('module');
+      $row            = Factory::getApplication()->bootComponent('com_modules')->getMVCFactory()->createTable('module');
       $row->title     = $title;
       $row->ordering  = $ordering;
       $row->position  = $position;

--- a/script.php
+++ b/script.php
@@ -14,6 +14,7 @@ use \Joomla\CMS\Uri\Uri;
 use \Joomla\CMS\Log\Log;
 use \Joomla\CMS\Language\Text;
 use \Joomla\CMS\Router\Route;
+use \Joomla\Filesystem\Path;
 use \Joomla\Filesystem\File;
 use \Joomla\Filesystem\Folder;
 use \Joomla\CMS\Installer\Installer;


### PR DESCRIPTION
This PR fixes the issue reported in #250 

There were still some J6 deprecations in the code which made JoomGallery break in Joomla 6. This PR should remove this deprecations.

### How to test this PR
Install the PR on a fresh Joomla 6 installations. Everything should work as you know it from within Joomla 5. No PHP errors.