### PR TITLE
Make DB prefix case-insensitive

### DIFF
--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -680,8 +680,8 @@ abstract class Migration implements MigrationInterface
     if($target === 'destination' || $this->params->get('same_db', 1))
     {
       // Get database driver of the current joomla application
-      $db        = Factory::getContainer()->get(DatabaseInterface::class);
-      $dbPrefix  = $this->app->get('dbprefix');
+      $db       = Factory::getContainer()->get(DatabaseInterface::class);
+      $dbPrefix = \strtolower($this->app->get('dbprefix'));
     }
     else
     {
@@ -693,7 +693,7 @@ abstract class Migration implements MigrationInterface
         $this->src_db = $dbFactory->getDriver($this->params->get('dbtype'), $options);
       }
 
-      $dbPrefix = $this->params->get('dbprefix');
+      $dbPrefix = \strtolower($this->params->get('dbprefix'));
       $db       = $this->src_db;
     }
 

--- a/script.php
+++ b/script.php
@@ -1365,7 +1365,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     {
       $db     = Factory::getContainer()->get(DatabaseInterface::class);
       $tables = $db->getTableList();
-      $prefix = Factory::getApplication()->get('dbprefix');
+      $prefix = strtolower(Factory::getApplication()->get('dbprefix'));
 
       if(empty($tables))
       {


### PR DESCRIPTION
This PR fixes the issue reported in the forum:
https://www.forum.joomgalleryfriends.net/forum/index.php?thread/507-fehler-bei-migration-pre-check

MySQL is case-insensitive in his table names. When entering uppercase DB prefix in database configuration, Joomla! automatically makes it lowercase such that it works correcly with the database. This behavior was different in JoomGallery before this PR.

### How to test this PR
- Install your Joomla by inserting an uppercase letter in the database prefix selection
- Joomla will successfully install and in your configuration.php will be an uppercase letter for the variable `$dbprefix`
- Looking at the database itself, you will see the same prefix in the names of the tables but in lowerase
- Starting the migration, in step 2 the pre-check will be successful (even with an uppercase letter in the db prefix)

(Apparently, this is how Joomla! behaves. We should follow this scheme, even if it is strange.)