### PR TITLE
[Refactor] Remove dynamic properties

### DIFF
--- a/administrator/com_joomgallery/src/Extension/ServiceTrait.php
+++ b/administrator/com_joomgallery/src/Extension/ServiceTrait.php
@@ -27,16 +27,23 @@ trait ServiceTrait
   /**
    * JoomGallery extension class
    * 
-   * @var JoomgalleryComponent
+   * @var JoomgalleryComponent|null
    */
   protected $component = null;
 
   /**
    * Current application object
    *
-   * @var    CMSApplicationInterface
+   * @var    CMSApplicationInterface|null
    */
   protected $app = null;
+
+  /**
+   * Internal store for dynamic properties.
+   *
+   * @var array<string, mixed>
+   */
+  protected array $__data = [];
 
   /**
 	 * Sets a default value if not already assigned
@@ -65,37 +72,14 @@ trait ServiceTrait
 	 *
 	 * @since   4.0.0
 	 */
-	public function get($property, $default = null)
+	public function get(string $property, $default = null)
 	{
-		if(isset($this->$property))
+		if(isset($this->__data[$property]))
 		{
-			return $this->$property;
+			return $this->__data[$property];
 		}
 
 		return $default;
-	}
-
-  /**
-	 * Returns an associative array of object properties.
-	 *
-	 * @param   boolean  $public  If true, returns only the public properties.
-	 *
-	 * @return  array
-	 *
-	 * @since   4.0.0
-	 */
-	public function getProperties($public = true)
-	{
-		if($public)
-		{
-			$vars = \Closure::fromCallable("get_object_vars")->__invoke($this);
-		}
-		else
-		{
-			$vars = \get_object_vars($this);
-		}
-
-		return $vars;
 	}
 
   /**
@@ -108,12 +92,57 @@ trait ServiceTrait
 	 *
 	 * @since   4.0.0
 	 */
-	public function set($property, $value = null)
+	public function set(string $property, $value = null)
 	{
-		$previous = $this->$property ?? null;
-		$this->$property = $value;
+		$previous = $this->__data[$property] ?? null;
+		$this->__data[$property] = $value;
 
 		return $previous;
+	}
+
+  /**
+	 * Returns an associative array of object properties.
+	 *
+	 * @param   boolean  $public  If true, returns only the public properties.
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0.0
+	 */
+	public function getProperties(bool $public = true): array
+	{
+    $vars = \array_merge(\get_object_vars($this), $this->__data);
+
+		if($public)
+    {
+      // Remove all properties starting with an underscore
+      foreach($vars as $key => $value)
+      {
+        if(\str_starts_with($key, '_'))
+        {
+          unset($vars[$key]);
+        }
+      }
+
+      // Now remove protected/private props declared in this class or parents
+      $reflection = new \ReflectionObject($this);
+      do {
+        $nonPublicProps = $reflection->getProperties(
+          \ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE
+        );
+
+        foreach($nonPublicProps as $prop)
+        {
+          $propName = $prop->getName();
+          if(\array_key_exists($propName, $vars))
+          {
+            unset($vars[$propName]);
+          }
+        }
+      } while ($reflection = $reflection->getParentClass());
+    }
+
+		return $vars;
 	}
 
   /**

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -183,7 +183,7 @@ abstract class IMGtools implements IMGtoolsInterface
    */
   public function types(): void
   {
-    $types = \implode(', ', $this->get('supported_types'));
+    $types = \implode(', ', $this->supported_types);
     $this->component->addDebug(Text::sprintf('COM_JOOMGALLERY_SERVICE_SUPPORTED_TYPES', $types));
 
     return;


### PR DESCRIPTION
Starting with PHP 8.2, dynamic properties are deprecated. Accessing or assigning properties that haven't been declared explicitly will trigger a deprecation notice. In PHP 9.0, this is expected to become a fatal error.

As the JoomGallery services and the JoomCache is still using dynamic properties this could break JoomGallery with PHP 9.0

This PR proposes code to implement a way to simulate dynamic properties by using associative arrays. Similar as Joomla! `Registry` class is doing, but in a much simpler way. This will allow us to still use get() and set() methods on our Service classes without the need to change working code there.

@ThomasFinnern Whats do you think about this implementation? 