### PR TITLE
[UI/UX] hide back button for root category

### DIFF
--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -142,7 +142,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php endif; ?>
 
 <?php // Back to parent category ?>
-<?php if($this->item->parent_id > 0) : ?>
+<?php if($this->item->parent_id > 1) : ?>
   <a class="jg-link btn btn-outline-primary" href="<?php echo Route::_('index.php?option=com_joomgallery&view=category&id='.(int) $this->item->parent_id); ?>">
     <i class="jg-icon-arrow-left-alt"></i><span><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_BACK_TO_PARENT'); ?></span>
   </a>


### PR DESCRIPTION
The root category has the ID 1 and cannot be managed, i.e. assigned images. This pull request ensures that the back button only appears for categories with images. Otherwise, clicking on it will take you to the same content.