### PR TITLE
Feat/Clean up custom fields tables when uninstalling

### DIFF
--- a/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -16,3 +16,6 @@ DROP TABLE IF EXISTS `#__joomgallery_votes`;
 DELETE FROM `#__assets` WHERE (name LIKE 'com_joomgallery%');
 DELETE FROM `#__content_types` WHERE (type_alias LIKE 'com_joomgallery%');
 DELETE FROM `#__mail_templates` WHERE (extension LIKE 'com_joomgallery%');
+DELETE `#__fields_values` FROM `#__fields_values` INNER JOIN `#__fields` ON `#__fields`.`id` = `#__fields_values`.`field_id` WHERE (`#__fields`.`context` LIKE 'com_joomgallery%');
+DELETE FROM `#__fields_groups` WHERE (context LIKE 'com_joomgallery%');
+DELETE FROM `#__fields` WHERE (context LIKE 'com_joomgallery%');


### PR DESCRIPTION
If you have defined your own fields in JoomGallery, these will not be deleted during uninstallation and remains in the database tables `#__fields_groups`, `#__fields` and `#__fields_values`
After a new installation, unexpected values may therefore be present.
### How to test this PR
Add Fields and Field groups to images and categories.
Enter various entries in these fields for both images and categories.
Uninstall JoomGallery component.
Check the entries in the database tables `#__fields_groups`, `#__fields` and `#__fields_values`: These must no longer contain any entries from JoomGallery. Entries that do not belong to JoomGallery should not be changed.