### PR TITLE
Deactivate plugins during installation

### DIFF
--- a/script.php
+++ b/script.php
@@ -88,6 +88,13 @@ class com_joomgalleryInstallerScript extends InstallerScript
    */
   protected $fromOldJG = false;
 
+  /**
+   * Storage array to store whatever needed during the script runtime
+   *
+   * @var  array
+   */
+  protected $storage = [];
+
 
 	/**
 	 * Method called before install/update the component. Note: This method won't be called during uninstall process.
@@ -150,6 +157,22 @@ class com_joomgalleryInstallerScript extends InstallerScript
 		{
 			return $result;
 		}
+
+    // Deactivate plugins that might interrupt install
+    $problemPlugins = ['versionable' => ['name' => null, 'type' => 'plugin', 'element' => 'versionable', 'folder' => 'behaviour']];
+    foreach($problemPlugins as $plugin)
+    {
+      if(!key_exists('problemPlugins', $this->storage))
+      {
+        $this->storage['problemPlugins'] = [];
+      }
+
+      if($id = $this->getExtensionID($plugin['name'], $plugin['type'], $plugin['element'], $plugin['folder']))
+      {
+        array_push($this->storage['problemPlugins'], $id);
+        $this->deactivateExtension($id);
+      }
+    }
 
     if($type == 'update')
     {
@@ -505,6 +528,15 @@ class com_joomgalleryInstallerScript extends InstallerScript
       {
         $app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_CONFIG', 'error'));
         Log::add(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_CONFIG'), 8, 'joomgallery');
+      }
+    }
+
+    // Re-activate previously deactivated Plugins
+    if(key_exists('problemPlugins', $this->storage))
+    {
+      foreach($this->storage['problemPlugins'] as $plugin_id)
+      {
+        $this->activateExtension($plugin_id);
       }
     }
   }
@@ -935,6 +967,51 @@ class com_joomgalleryInstallerScript extends InstallerScript
   }
 
   /**
+	 * Tries to get an extension id based on information
+   *
+   * @param   string $name     Extension name
+   * @param   string $type     Extension type
+   * @param   string $element  Extension element
+   * @param   string $folder   Extension folder
+   *
+	 * @return  int  Extension id
+	 */
+  private function getExtensionID($name=null, $type=null, $element=null, $folder=null)
+  {
+    $db    = Factory::getContainer()->get(DatabaseInterface::class);
+    $query = $db->getQuery(true);
+
+    $query->select('extension_id')
+					->from('#__extensions');
+    
+    if($name)
+    {
+      $query->where('name = ' . $db->quote($name));
+    }
+
+    if($type)
+    {
+      $query->where('type = ' . $db->quote($type));
+    }
+
+    if($element)
+    {
+      $query->where('element = ' . $db->quote($element));
+    }
+
+    if($folder)
+    {
+      $query->where('folder = ' . $db->quote($folder));
+    }
+
+    $db->setQuery($query);
+
+    $id = $db->loadResult();
+
+    return $id ? $id : 0;
+  }
+
+  /**
 	 * Deactivate an extension based on its id
 	 *
 	 * @param  int   $id  The ID of the extension to be deactivated
@@ -949,6 +1026,27 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $query->update($db->quoteName('#__extensions'))
           ->set($db->quoteName('enabled'). ' = 0')
 					->where($db->quoteName('extension_id') . ' = ' . $id);
+		
+    $db->setQuery($query);
+		
+    return $db->execute();
+  }
+
+  /**
+   * Activate an extension based on its id
+   *
+   * @param  int   $id  The ID of the extension to be activated
+   *
+   * @return void
+   */
+  private function activateExtension($id)
+  {
+    $db    = Factory::getContainer()->get(DatabaseInterface::class);
+    $query = $db->getQuery(true);
+
+    $query->update($db->quoteName('#__extensions'))
+          ->set($db->quoteName('enabled'). ' = 1')
+          ->where($db->quoteName('extension_id') . ' = ' . $id);
 		
     $db->setQuery($query);
 		


### PR DESCRIPTION
This PR solves the issue repoerted in https://github.com/JoomGalleryfriends/JoomGallery/issues/274.

A change in the `Behaviour - Versionable` Plugin from Joomla! 5 to Joomla! 6, breaks the installation of the JoomGallery component in Joomla! 6.
This PR solves this issue by deactivating the corresponding plugin during the installation and reactivates it afterwards.

### How to test this PR
Installation of JoomGallery should work now in all supported Joomla versions (4, 5, 6).