### PR TITLE
Image delete: Delete all entries in other tables

### DIFF
--- a/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -766,13 +766,42 @@ class ImageModel extends JoomAdminModel
 					}
 
 					// Delete corresponding comments
+					$db = $this->getDatabase();
+					$query = $db->getQuery(true)
+							->delete($db->quoteName('#__joomgallery_comments'))
+							->where(
+									$db->quoteName('imgid') . ' = :pk',
+							)
+							->bind(':pk', $pk, ParameterType::INTEGER);
+
+						$db->setQuery($query);
+						$db->execute();
 
 					// Delete corresponding votes
+					$query = $db->getQuery(true)
+							->delete($db->quoteName('#__joomgallery_votes'))
+							->where(
+									$db->quoteName('imgid') . ' = :pk',
+							)
+							->bind(':pk', $pk, ParameterType::INTEGER);
+
+						$db->setQuery($query);
+						$db->execute();
+
+					// Delete corresponding collection reference
+					$query = $db->getQuery(true)
+							->delete($db->quoteName('#__joomgallery_collections_ref'))
+							->where(
+									$db->quoteName('imgid') . ' = :pk',
+							)
+							->bind(':pk', $pk, ParameterType::INTEGER);
+
+						$db->setQuery($query);
+						$db->execute();
 
 					// Multilanguage: if associated, delete the item in the _associations table
 					if($this->associationsContext && Associations::isEnabled())
 					{
-						$db = $this->getDatabase();
 						$query = $db->getQuery(true)
 							->select(
 								[


### PR DESCRIPTION
### Before this PR
When deleting an image, associated entries in certain linked tables are not deleted.
This can lead to problems during later migrations, because the tables are not empty.
This affects entries in the following tables:
#__joomgallery_comments
#__joomgallery_votes
#__joomgallery_collections_ref (is currently not used)

### How to test this PR
Perform a migration where the images also have votes and comments.
Delete the images in JG4. Check in phpMyAdmin whether the entries in the above tables have also been deleted.