### PR TITLE
Delete the tasks table during uninstallation

### DIFF
--- a/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -10,6 +10,7 @@ DROP TABLE IF EXISTS `#__joomgallery_img_types`;
 DROP TABLE IF EXISTS `#__joomgallery_migration`;
 DROP TABLE IF EXISTS `#__joomgallery_tags`;
 DROP TABLE IF EXISTS `#__joomgallery_tags_ref`;
+DROP TABLE IF EXISTS `#__joomgallery_tasks`;
 DROP TABLE IF EXISTS `#__joomgallery_users`;
 DROP TABLE IF EXISTS `#__joomgallery_votes`;
 


### PR DESCRIPTION
PR https://github.com/JoomGalleryfriends/JoomGallery/pull/257 introduced a new table `#__joomgallery_tasks`.
However, this table is not deleted during uninstallation.

### Actual result
Install the PR https://github.com/JoomGalleryfriends/JoomGallery/pull/257.
Uninstall JoomGallery.
Check whether the table `#__joomgallery_task`s still exists.

### How to test this PR
Install this pull request.
Uninstall JoomGallery.
Check whether the table `#__joomgallery_tasks` still exists.