### PR TITLE
Install issues

### DIFF
--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -481,6 +481,7 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
     $checkQuery->where('level = 0');
 
     $db->setQuery($checkQuery);
+    $date = Factory::getDate();
 
     // Add root category
     if(empty($db->loadAssoc()))
@@ -498,6 +499,8 @@ class CategoryTable extends MultipleAssetsTable implements VersionableTableInter
       ->set('access = 1')
       ->set('published = 1')
       ->set('params = ' . $db->quote(''))
+      ->set('created_time = ' . $db->quote($date->toSql()))
+      ->set('modified_time = ' . $db->quote($date->toSql()))
       ->set('language = ' . $db->quote('*'))
       ->set('metadesc = ' . $db->quote(''))
       ->set('metakey = ' . $db->quote(''));

--- a/script.php
+++ b/script.php
@@ -602,6 +602,8 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $data['language'] = $language;
     $data['subject'] = 'COM_JOOMGALLERY_MAIL_'.strtoupper($context_id).'_SUBJECT';
     $data['body'] = 'COM_JOOMGALLERY_MAIL_'.strtoupper($context_id).'_BODY';
+    $data['htmlbody'] = '';
+    $data['attachments'] = '';
     $data['params'] = json_encode($params);
 
     if (!$table->bind($data))
@@ -684,6 +686,8 @@ class com_joomgalleryInstallerScript extends InstallerScript
       return false;
     }
 
+    $date = Factory::getDate();
+
     $data = array();
     $data["id"] = null;
     $data["asset_id"] = null;
@@ -699,6 +703,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $data["thumbnail"] = "0";
     $data["params"] = '{"allow_download":"-1","allow_comment":"-1","allow_rating":"-1","allow_watermark":"-1","allow_watermark_download":"-1"}';
     $data["language"] = "*";
+    $data["modified_time"] = $date->toSql();
     $data["metadesc"] = "";
     $data["metakey"] = "";
     $data["rules"] = "{}";
@@ -832,6 +837,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $gallerydata['menutype'] = 'mainmenu';
     $gallerydata['title'] = 'JoomGallery';
     $gallerydata['alias'] = 'gallery';
+    $gallerydata['path'] = 'gallery';
     $gallerydata['language'] = '*';
     $gallerydata['link'] = 'index.php?option=com_joomgallery&view=gallery';
     $gallerydata['type'] = 'component';
@@ -839,6 +845,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $gallerydata['level'] = 1;
     $gallerydata['component_id'] = $com_id;
     $gallerydata['access'] = 1;
+    $gallerydata['img'] = 'class:component';
     $gallerydata['params'] = '{"menu_show":1}';
 
     if (!$table->bind($gallerydata))
@@ -872,6 +879,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $catdata['menutype'] = 'mainmenu';
     $catdata['title'] = 'Categories';
     $catdata['alias'] = 'categories';
+    $catdata['path'] = 'gallery/categories';
     $catdata['language'] = '*';
     $catdata['link'] = 'index.php?option=com_joomgallery&view=category&id=1';
     $catdata['type'] = 'component';
@@ -880,6 +888,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $catdata['level'] = 2;
     $catdata['component_id'] = $com_id;
     $catdata['access'] = 1;
+    $catdata['img'] = 'class:component';
     $catdata['params'] = '{"menu_show":0}';
 
     if (!$table->bind($catdata))
@@ -910,6 +919,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $imgsdata['menutype'] = 'mainmenu';
     $imgsdata['title'] = 'Images';
     $imgsdata['alias'] = 'images';
+    $imgsdata['path'] = 'gallery/images';
     $imgsdata['language'] = '*';
     $imgsdata['link'] = 'index.php?option=com_joomgallery&view=images';
     $imgsdata['type'] = 'component';
@@ -918,6 +928,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $imgsdata['level'] = 2;
     $imgsdata['component_id'] = $com_id;
     $imgsdata['access'] = 1;
+    $imgsdata['img'] = 'class:component';
     $imgsdata['params'] = '{"menu_show":0}';
 
     if (!$table->bind($imgsdata))


### PR DESCRIPTION
Thanks to @eumel1602 who has pointed me to an error he got during update, I found some issues you get when you do a fresh installation of JoomGallery in Joomla! 5.4 or newer.

![505114555-7e38e57b-e11c-4ca7-bb35-e6e61bea5015](https://github.com/user-attachments/assets/f2fbdc9e-0d91-416b-bdce-b2c6ffe08d66)

This error appears if the default items are not created during installation. Apparently default category, mail templates and menu entries do not get created anymore during installation.

Seems like Joomla! core intruduced some changes in the db tables:
- #__mail_templates
- #__menu

### How to test this PR
Without this PR applies, in a fresh Joomla! installation, after the JoomGallery installation the above posted error appears.
With this PR, the error does not appear anymore.
