### PR TITLE
Fix display error when only 1 (one) tag is assigned to an image

### DIFF
--- a/site/com_joomgallery/layouts/joomgallery/content/tags.php
+++ b/site/com_joomgallery/layouts/joomgallery/content/tags.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $nmb = count((array) $displayData);
 ?>
 
-<?php if(!empty($displayData) && count((array) $displayData) > 1) : ?>
+<?php if(!empty($displayData) && count((array) $displayData) > 0) : ?>
     <ul class="tags list-inline">
         <?php foreach($displayData as $i => $tag) : ?>
             <li class="list-inline-item tag-<?php echo $tag->id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">


### PR DESCRIPTION
Single image view:
If only 1 'one' tag is assigned to a image, this tag will not be displayed.
If several tag are assigned to an image, all of them will be displayed.

DE:
Einzelbild-Ansicht:
Wenn einem Bild nur 1 'ein' Tag/Schlagwort zugeordnet ist, wird dieses Tag/Schlagwort nicht angezeigt.
Wenn einem Bild mehrere Tags/Schlagwörter zugeordnet sind, werden alle angezeigt.
