### PR TITLE
Fix wrong default value for 'jg_maxfilesize'

### DIFF
--- a/script.php
+++ b/script.php
@@ -783,7 +783,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $data["jg_maxusercat"] = 10;
     $data["jg_maxuserimage"] = 500;
     $data["jg_maxuserimage_timespan"] = 0;
-    $data["jg_maxfilesize"] = 2000000;
+    $data["jg_maxfilesize"] = 2;
     $data["jg_maxuploadfields"] = 3;
     $data["jg_maxvoting"] = 5;
 


### PR DESCRIPTION
With [PR256](https://github.com/JoomGalleryfriends/JoomGallery/pull/256), the default value for 'jg_maxfilesize' should be set to '2' MB.
Unfortunately, this does not work in new installations because the value is set differently in the script file for new installations.
This PR fixes that.