### PR TITLE
Fix Deprecated warnings

### DIFF
--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -109,7 +109,7 @@ abstract class JoomAdminModel extends AdminModel
    * @since   4.0.0
    * @throws  \Exception
    */
-  public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+  public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
   {
     parent::__construct($config, $factory, $formFactory);
 

--- a/administrator/com_joomgallery/tmpl/image/edit.php
+++ b/administrator/com_joomgallery/tmpl/image/edit.php
@@ -200,7 +200,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
 
 <?php
 $mediaManagerBtn = '<joomla-toolbar-button><button class="btn disabled" disabled>'.Text::_('COM_JOOMGALLERY_IMAGE_EDIT').'</button></joomla-toolbar-button>';
-if(in_array(strtolower(pathinfo($this->item->filename, PATHINFO_EXTENSION)), ['jpg', 'jpeg', 'png']))
+if(!\is_null($this->item->filename) && in_array(strtolower(pathinfo($this->item->filename, PATHINFO_EXTENSION)), ['jpg', 'jpeg', 'png']))
 {
   $mediaManagerBtn = '<joomla-toolbar-button id="toolbar-openmedia" task="image.openmedia"><button class="btn hasTip" title="'.Text::_('COM_JOOMGALLERY_IMAGE_EDIT_TIP').'">'.Text::_('COM_JOOMGALLERY_IMAGE_EDIT').'</button></joomla-toolbar-button>';
 }


### PR DESCRIPTION
This PR fixes the following Deprecated Warnings:
1. In Edit Image Template: Issue https://github.com/JoomGalleryfriends/JoomGallery/issues/301
2. In JoomAdminModel: https://www.forum.joomgalleryfriends.net/forum/index.php?thread/535-deprecated-messages-on-joomla-6-0-0-with-joomgallery-4-2-0/

If there are any other deprecated messages, please post it.
