### PR TITLE
Show message unicodes slugs only in backend

### DIFF
--- a/administrator/com_joomgallery/src/View/JoomGalleryView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryView.php
@@ -102,7 +102,7 @@ class JoomGalleryView extends BaseHtmlView
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION'), 'warning');
     }
 
-    if($this->app->get('unicodeslugs', false))
+    if($this->app->isClient('administrator') && $this->app->get('unicodeslugs', false))
     {
       // The option unicodeslugs is activated.
       $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNICODESLUGS'), 'warning');


### PR DESCRIPTION
This PR fixes the issue that the message about the activated unicode slugs was also shown in the fronted.

### How to test this PR
Before applying this PR, when unicode slugs are activated in the Joomla! configuration, there is an untranslated string shown in the frontend views.

After this PR, there is no message shown anymore in the frontend, but only in the backend.