### PR TITLE
Fixes for manual start of fixCodeStyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /administrator/com_joomgallery/joomgallery.xml
 /administrator/com_joomgallery/joomgallery_old.xml
 /administrator/com_joomgallery/vendor
+/tools/*.log
 .DS_Store
 Thumbs.db
 node_modules

--- a/tools/checkCodeBy_cs_cbf.bat
+++ b/tools/checkCodeBy_cs_cbf.bat
@@ -66,21 +66,24 @@ REM Composer housekeeping
 
 ECHO Install and update needed dependencies (composer)
 
-composer dump-autoload
+echo "--- composer dump-autoload"
+call composer dump-autoload
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer dump-autoload failed!
     GOTO :ErrorBack
 )
 
-composer install
+echo "--- composer install"
+call composer install
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer install failed!
     GOTO :ErrorBack
 )
 
-composer update
+echo "--- composer update"
+call composer update
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer update failed!
@@ -94,12 +97,12 @@ REM =====================================================
 REM call "phpcs"
 
 ECHO ----------------------------------------------
-ECHO call "phpcbf"
+ECHO call "phpcs"
 ECHO    may take some time 
 
 php ".\administrator\com_joomgallery\vendor\bin\phpcs" --standard=ruleset.xml .\
 REM if errorlevel 1 (
-REM 	ECHO Error on calling phpcbf (02)
+REM 	ECHO Error on calling phpcs (02)
 REM 	goto :ErrorBack
 REM )	
 ECHO.

--- a/tools/checkCodeBy_cs_cbf.sh
+++ b/tools/checkCodeBy_cs_cbf.sh
@@ -70,7 +70,7 @@ fi
 echo "Install and update needed dependencies (composer)"
 echo
 
-echo "composer dump-autoload"
+echo "--- composer dump-autoload"
 composer dump-autoload
 if [ $? -ne 0 ]; then
     echo
@@ -79,7 +79,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer install"
+echo "--- composer install"
 composer install
 if [ $? -ne 0 ]; then
     echo
@@ -88,7 +88,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer update"
+echo "--- composer update"
 composer update
 if [ $? -ne 0 ]; then
     echo

--- a/tools/checkCodeBy_cs_fixer.bat
+++ b/tools/checkCodeBy_cs_fixer.bat
@@ -66,21 +66,24 @@ REM Composer housekeeping
 
 ECHO Install and update needed dependencies (composer)
 
-composer dump-autoload
+echo "--- composer dump-autoload"
+call composer dump-autoload
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer dump-autoload failed!
     GOTO :ErrorBack
 )
 
-composer install
+echo "--- composer install"
+call composer install
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer install failed!
     GOTO :ErrorBack
 )
 
-composer update
+echo "--- composer update"
+call composer update
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer update failed!

--- a/tools/checkCodeBy_cs_fixer.sh
+++ b/tools/checkCodeBy_cs_fixer.sh
@@ -71,7 +71,7 @@ fi
 echo "Install and update needed dependencies (composer)"
 echo
 
-echo "composer dump-autoload"
+echo "--- composer dump-autoload"
 composer dump-autoload
 if [ $? -ne 0 ]; then
     echo
@@ -80,7 +80,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer install"
+echo "--- composer install"
 composer install
 if [ $? -ne 0 ]; then
     echo
@@ -89,7 +89,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer update"
+echo "--- composer update"
 composer update
 if [ $? -ne 0 ]; then
     echo

--- a/tools/fixCodeStyle.bat
+++ b/tools/fixCodeStyle.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 REM -----------------------------------------------------
-REM Fix joomgallery code style (jg_fixCodeStyle.bat)
+REM Fix joomgallery code style (fixCodeStyle.bat)
 REM -----------------------------------------------------
 REM This batch calls following task succession to apply
 REM JG defined codestyle
@@ -73,21 +73,24 @@ REM Composer housekeeping
 
 ECHO Install and update needed dependencies (composer)
 
-composer dump-autoload
+echo "--- composer dump-autoload"
+call composer dump-autoload
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer dump-autoload failed!
     GOTO :ErrorBack
 )
 
-composer install
+echo "--- composer install"
+call composer install
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer install failed!
     GOTO :ErrorBack
 )
 
-composer update
+echo "--- composer update"
+call composer update
 IF errorlevel 1 (
     ECHO.
     ECHO ERROR: composer update failed!

--- a/tools/fixCodeStyle.md
+++ b/tools/fixCodeStyle.md
@@ -1,0 +1,48 @@
+# Fix code style
+
+Developers may prepare their code style before checkin
+JG uses its own codestyle. See github doc folder
+The scripts could not achive all aspects but may improve over time
+
+## Call the script
+
+use fixCodeStyle.bat or fixCodeStyle.sh depending on operation system.
+Start the script in tools folder.
+
+php and composer must be available over the path environment.
+
+The scxript will move to the root folder and call the following commands from there
+
+1) Check if PHP is available
+1) Move to jg_basePath 
+1) Verify that we are in the correct working directory
+1) Install and update needed dependencies (composer)
+1) Fix 01: call "php-cs-fixer" 
+1) Fix 02: call "phpcbf"
+1) Fix 03: call "php-cs-fixer"  
+1) Move back
+
+## Results 
+
+The code style is now improved as good as it gets
+
+You will find three log files telling about the results
+
+- 01.php-cs-fixer.log
+- 02.phpcbf.log
+- 03.php-cs-fixer.log
+
+These can be ignored
+
+# On error of script
+
+On error of script the actual folder may be on the root instead of tools
+A call of ```popd``` in the command line will bring you back
+
+# Further scripts
+
+The scripts used may be called separately 
+
+* checkCodeBy_cs_fixer
+* checkCodeBy_cs_cbf
+

--- a/tools/fixCodeStyle.sh
+++ b/tools/fixCodeStyle.sh
@@ -78,7 +78,7 @@ fi
 echo "Install and update needed dependencies (composer)"
 echo
 
-echo "composer dump-autoload"
+echo "--- composer dump-autoload"
 composer dump-autoload
 if [ $? -ne 0 ]; then
     echo
@@ -87,7 +87,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer install"
+echo "--- composer install"
 composer install
 if [ $? -ne 0 ]; then
     echo
@@ -96,7 +96,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "composer update"
+echo "--- composer update"
 composer update
 if [ $? -ne 0 ]; then
     echo


### PR DESCRIPTION
Tested manual start of fixCodeStyle on windows. found improvements
On windows the composer must be started with 'call composer ..."
Added fixCodeStyle.md