### PR TITLE
No issue with Versionable plugin in J6.0.1

### DIFF
--- a/script.php
+++ b/script.php
@@ -167,7 +167,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
     foreach($problemPlugins as $plugin)
     {
-      if(version_compare($jversion[0], $plugin['jversion'], '>='))
+      if(version_compare($jversion[0], $plugin['jversion'], '=='))
       {
         if(!key_exists('problemPlugins', $this->storage))
         {
@@ -180,9 +180,6 @@ class com_joomgalleryInstallerScript extends InstallerScript
           $language->load($plugin['name'], JPATH_ADMINISTRATOR);
 
           Factory::getApplication()->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_DEACTIVATE_PLUGIN', $plugin['folder'], Text::_(strtoupper($plugin['name']))), 'error');
-
-          //array_push($this->storage['problemPlugins'], $id);
-          //$this->deactivateExtension($id);
 
           return false;
         }


### PR DESCRIPTION
With PR #280 we introduced a check during installation, that the `Behaviour - Versionable` Plugin needs to be deactivated before installation on Joomla! 6.

With Joomla! 6.0.1 the issue was fixed in the core and thus the `Behaviour - Versionable` Plugin does not need to be deactivated anymore. This PR adjusts the check in the installation script such that the message only appeary on Joomla! 6 sides. Joomla! 6.0.1 and newer can be installed the normal way.

### How to test this PR

- Install the PR in a Joomla 5.x installation with `Behaviour - Versionable` Plugin activated
  --> install should work
- Install the PR in a Joomla 6.0.0 installation with `Behaviour - Versionable` Plugin activated
   --> install should be cancelled with a message to deactivate the plugin.
- Install the PR in a Joomla 6.0.1 or newer installation with `Behaviour - Versionable` Plugin activated
   --> install should work