### PR TITLE
Fix Frontend Router

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.sys.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.sys.ini
@@ -88,9 +88,9 @@ COM_JOOMGALLERY_MENU_SHOW_USER_IMAGES_MANAGE_DESC="Display user images as manage
 
 COM_JOOMGALLERY_VIEW_USER_CATEGORY_EDIT_TITLE="User: Edit/create user category"
 COM_JOOMGALLERY_VIEW_USER_CATEGORY_EDIT_DESC="Select an existing category or create a new one"
-COM_JOOMGALLERY_VIEW_USER_CATEGORY_TITLE="User: Display user category"
+COM_JOOMGALLERY_VIEW_USER_CATEGORY_TITLE="User: Category"
 COM_JOOMGALLERY_VIEW_USER_CATEGORY_FORM_DESC="Display the user category fields in readonly mode"
-COM_JOOMGALLERY_MENU_VIEW_USER_CATEGORIES="User: List categories of one user"
+COM_JOOMGALLERY_MENU_VIEW_USER_CATEGORIES="User: List categories"
 COM_JOOMGALLERY_MENU_VIEW_USER_CATEGORIES_DESC="Display a list of categories for selected user (table layout and filter)"
 COM_JOOMGALLERY_MENU_VIEW_USER_IMAGES_TITLE="User: List of Images"
 COM_JOOMGALLERY_MENU_VIEW_USER_IMAGES_DESC="Frontend administration: Display a list of images (table layout and filters)"

--- a/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
+++ b/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
@@ -45,6 +45,7 @@ use Joomla\CMS\Component\Router\RouterInterface;
 use Joomla\CMS\Component\Router\RouterServiceInterface;
 use Joomla\CMS\Component\Router\RouterServiceTrait;
 use Joomla\CMS\Extension\BootableExtensionInterface;
+use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Fields\FieldsServiceInterface;
@@ -111,6 +112,13 @@ RouterServiceTrait::createRouter as traitCreateRouter;
   public $version = '';
 
   /**
+   * Storage for the current component version
+   *
+   * @var object
+   */
+  public $extension = null;
+
+  /**
    * Booting the extension. This is the function to set up the environment of the extension like
    * registering new class loaders, etc.
    *
@@ -147,6 +155,12 @@ RouterServiceTrait::createRouter as traitCreateRouter;
     if(!$this->version)
     {
       $this->version = (string) $this->xml->version;
+    }
+
+    // Load component object from #__extensions table
+    if(!$this->extension)
+    {
+      $this->extension = ExtensionHelper::getExtensionRecord(_JOOM_OPTION, 'component');
     }
   }
 

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -937,8 +937,8 @@ class JoomHelper
     $comp_id = self::getComponent()->extension->extension_id;
 
     $items = $menu->getItems(
-      ['type', 'component_id', 'access'],
-      ['component', $comp_id, null]
+        ['type', 'component_id', 'access'],
+        ['component', $comp_id, null]
     );
 
     if(!empty($items))
@@ -970,11 +970,13 @@ class JoomHelper
         if($count > 1)
         {
           // We have multiple matching menuitems
-          usort($findings, function($a, $b)
-          {
-            // Lets take the one with the lowest level value
-            return $a->level - $b->level;
-          });
+        usort(
+            $findings,
+            function ($a, $b) {
+              // Lets take the one with the lowest level value
+              return $a->level - $b->level;
+            }
+        );
         }
 
         return $findings[0]->id;
@@ -982,6 +984,7 @@ class JoomHelper
     }
 
     $default = $menu->getDefault();
+
     return $default ? (int) $default->id : 0;
   }
 

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -56,6 +56,13 @@ class JoomHelper
   ];
 
   /**
+   * List of all supported image types
+   *
+   * @var array
+   */
+  public static $image_types = ['raw', 'gif', 'jpeg', 'jpg', 'png', 'webp'];
+
+  /**
    * Gets the JoomGallery component object
    *
    * @return  Joomgallery\Component\Joomgallery\Administrator\Extension\JoomgalleryComponent
@@ -905,9 +912,7 @@ class JoomHelper
   {
     if($url)
     {
-      $menuitem = self::getMenuItem('images');
-
-      return Route::_(self::getViewRoute('image', 0, 1, 'raw', $type, null, null, $menuitem));
+      return Route::_(self::getViewRoute('image', 0, 1, 'raw', $type));
     }
 
     // Create file manager service

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -709,7 +709,7 @@ class JoomHelper
    *
    * @since   4.0.0
    */
-  public static function getViewRoute($view, $id = 0, $catid = 0, $format = null, $type = null, $language = null, $layout = null)
+  public static function getViewRoute($view, $id = 0, $catid = 0, $format = null, $type = null, $language = null, $layout = null, $menuitem = null)
   {
     if(\is_object($id))
     {
@@ -757,6 +757,11 @@ class JoomHelper
     if($layout)
     {
       $link .= '&layout=' . $layout;
+    }
+
+    if($menuitem)
+    {
+      $link .= '&Itemid=' . $menuitem;
     }
 
     return $link;
@@ -900,14 +905,79 @@ class JoomHelper
   {
     if($url)
     {
-      return Route::_(self::getViewRoute('image', 0, 1, 'raw', $type));
+      $menuitem = self::getMenuItem('images');
+
+      return Route::_(self::getViewRoute('image', 0, 1, 'raw', $type, null, null, $menuitem));
     }
 
+    // Create file manager service
+    $manager = self::getService('FileManager', [1]);
 
-      // Create file manager service
-      $manager = self::getService('FileManager', [1]);
+    return $manager->getImgPath(0, $type, false, false, $root);
+  }
 
-      return $manager->getImgPath(0, $type, false, false, $root);
+  /**
+   * Returns a menuitem id of a specific JoomGallery view
+   *
+   * @param   string  $view      Menuitem type
+   * @param   int     $childof   Menuitem must be a child of this menuitem (id)
+   *
+   * @return  int   Menuitem id
+   *
+   * @since   4.0.0
+   */
+  public static function getMenuItem($view, $childof = null)
+  {
+    $menu    = Factory::getApplication()->getMenu();
+    $comp_id = self::getComponent()->extension->extension_id;
+
+    $items = $menu->getItems(
+      ['type', 'component_id', 'access'],
+      ['component', $comp_id, null]
+    );
+
+    if(!empty($items))
+    {
+      $findings = [];
+
+      foreach($items as $menuitem)
+      {
+        if(($menuitem->query['view'] ?? null) !== $view)
+        {
+          continue;
+        }
+
+        if($childof !== null)
+        {
+          // Check that this menuitem is a child of the given menuitem
+          if(empty($menuitem->tree) || !\in_array((int) $childof, $menuitem->tree))
+          {
+            continue;
+          }
+        }
+
+        // We found a menuitem of the corresponding type
+        $findings[] = $menuitem;
+      }
+
+      if($count = \count($findings))
+      {
+        if($count > 1)
+        {
+          // We have multiple matching menuitems
+          usort($findings, function($a, $b)
+          {
+            // Lets take the one with the lowest level value
+            return $a->level - $b->level;
+          });
+        }
+
+        return $findings[0]->id;
+      }
+    }
+
+    $default = $menu->getDefault();
+    return $default ? (int) $default->id : 0;
   }
 
   /**

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -44,9 +44,14 @@ class RawView extends JoomGalleryView
     $type = $this->app->input->get('type', 'thumbnail', 'word');
     $id   = $this->app->input->get('id', 0);
 
+    if($id == 0 || $id == '0')
+    {
+      $id = 'null';
+    }
+
     if($id !== 'null')
     {
-    $id = $this->app->input->get('id', 0, 'int');
+      $id = $this->app->input->get('id', 0, 'int');
     }
 
     // Check access

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -138,8 +138,7 @@ class DefaultRouter extends RouterView
     $this->registerView($usercategories);
 
     $usercategory = new RouterViewConfiguration('usercategory');
-    $usercategory->setKey('id')->setNestable()->setParent($usercategories);
-    //$usercategory->setParent($userpanel);
+    $usercategory->setKey('id')->setNestable()->setParent($userpanel);
     $this->registerView($usercategory);
 
     $userimages = new RouterViewConfiguration('userimages');

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -165,7 +165,7 @@ class DefaultRouter extends RouterView
   public function preprocess($query)
   {
     // Check for a controller.task command.
-    if(isset($query['task']) && \str_contains($query['task'], '.'))
+    if(isset($query['task']) && str_contains($query['task'], '.'))
     {
       [$view, $task] = explode('.', $query['task']);
 
@@ -414,7 +414,7 @@ class DefaultRouter extends RouterView
             return [0 => 'newcat', 1 => 'categories'];
           }
 
-          return [0 => '0:newcat', 1 => '1:categories', ];
+          return [0 => '0:newcat', 1 => '1:categories'];
         }
       }
     }

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -406,9 +406,7 @@ class DefaultRouter extends RouterView
       if($segment == '0-' || $segment == 'noimage' || $segment == '0-noimage')
       {
         // Special case: No image with id=0
-        // return 'null'; wrong
-        // return false;    // ToDo: FiTh/Manuel Discussion => int or false ... ?
-        return 0;
+        return 'null';
       }
 
       $img_id = $this->getImageIdDb($segment, $query);

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -183,8 +183,16 @@ class DefaultRouter extends RouterView
     {
       if(!$id)
       {
-        // Load empty form view
-        return [''];
+        if($query['view'] = 'image' && $query['format'] = 'raw')
+        {
+          // Load the no-image
+          return [0 => '0:noimage'];
+        }
+        elseif($query['view'] = 'userimage')
+        {
+          // Load empty userimage form view
+          return [''];
+        }
       }
 
       $id .= ':' . $this->getImageAliasDb($id);
@@ -380,11 +388,11 @@ class DefaultRouter extends RouterView
    * @param   string   $segment  Segment of the image to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int|false   The id of this item or false
+   * @return  mixed    The id of this item or false
    *
    * @since   4.2.0
    */
-  public function getGalleryId($segment, $query): int|false
+  public function getGalleryId($segment, $query)
   {
     return (int) $segment;
   }
@@ -395,26 +403,21 @@ class DefaultRouter extends RouterView
    * @param   string   $segment  Segment of the image to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int|false   The id of this item or false
+   * @return  mixed    The id of this item or false
    *
    * @since   4.2.0
    */
-  public function getImageId($segment, $query): int|false
+  public function getImageId($segment, $query)
   {
-    if($this->noIDs)
+    if($segment == '0-' || $segment == 'noimage' || $segment == '0-noimage')
     {
-      if($segment == '0-' || $segment == 'noimage' || $segment == '0-noimage')
-      {
-        // Special case: No image with id=0
-        return 'null';
-      }
-
-      $img_id = $this->getImageIdDb($segment, $query);
-
-      return (int) $img_id;
+      // Special case: No image with id=0
+      return 'null';
     }
 
-    return (int) $segment;
+    $img_id = $this->getImageIdDb($segment, $query);
+
+    return (int) $img_id;
   }
 
   /**
@@ -423,18 +426,13 @@ class DefaultRouter extends RouterView
    * @param   string   $segment  Segment of the image to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int|false   The id of this item or false
+   * @return  mixed    The id of this item or false
    *
    * @since   4.2.0
    */
-  public function getImagesId($segment, $query): int|false
+  public function getImagesId($segment, $query)
   {
-    if($this->noIDs)
-    {
-      return $this->getImageId($segment, $query);
-    }
-
-    return (int) $segment;
+    return $this->getImageId($segment, $query);
   }
 
   /**
@@ -443,57 +441,52 @@ class DefaultRouter extends RouterView
    * @param   string   $segment  Segment of the category to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int|false   The id of this item or false
+   * @return  mixed    The id of this item or false
    *
    * @since   4.2.0
    */
-  public function getCategoryId($segment, $query): int|false
+  public function getCategoryId($segment, $query)
   {
-    if($this->noIDs)
+    if(isset($query['id']) && ($query['id'] === 0 || $query['id'] === '0'))
     {
-      if(isset($query['id']) && ($query['id'] === 0 || $query['id'] === '0'))
-      {
-        // Root element of nestable content in core must have the id=0
-        // But JoomGallery category root has id=1
-        $query['id'] = 1;
-      }
+      // Root element of nestable content in core must have the id=0
+      // But JoomGallery category root has id=1
+      $query['id'] = 1;
+    }
 
-      if(strpos($segment, 'categories'))
-      {
-        // If 'categories' is in the segment, means that we are looking for the root category
-        $segment = str_replace('categories', 'root', $segment);
-      }
+    if(strpos($segment, 'categories'))
+    {
+      // If 'categories' is in the segment, means that we are looking for the root category
+      $segment = str_replace('categories', 'root', $segment);
+    }
 
-      if(isset($query['id']))
-      {
-        $category = $this->getCategory((int) $query['id'], 'children', true);
+    if(isset($query['id']))
+    {
+      $category = $this->getCategory((int) $query['id'], 'children', true);
 
-        if($category)
+      if($category)
+      {
+        foreach($category->children as $child)
         {
-          foreach($category->children as $child)
+          if($this->noIDs)
           {
-            if($this->noIDs)
+            if($child['alias'] == $segment)
             {
-              if($child['alias'] == $segment)
-              {
-                return $child['id'];
-              }
+              return $child['id'];
             }
-            else
+          }
+          else
+          {
+            if($child['id'] == (int) $segment)
             {
-              if($child['id'] == (int) $segment)
-              {
-                return $child['id'];
-              }
+              return $child['id'];
             }
           }
         }
       }
-
-      return false;
     }
 
-    return (int) $segment;
+    return false;
   }
 
   /**
@@ -563,18 +556,13 @@ class DefaultRouter extends RouterView
    * @param   string   $segment  Segment of the category to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int|false   The id of this item or false
+   * @return  mixed    The id of this item or false
    *
    * @since   4.2.0
    */
-  public function getCategoriesId($segment, $query): int|false
+  public function getCategoriesId($segment, $query)
   {
-    if($this->noIDs)
-    {
-      return $this->getCategoryId($segment, $query);
-    }
-
-    return (int) $segment;
+    return $this->getCategoryId($segment, $query);
   }
 
   /**

--- a/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -135,7 +135,7 @@ class JG3ModernRouter extends DefaultRouter
     $this->registerView($usercategories);
 
     $usercategory = new RouterViewConfiguration('usercategory');
-    $usercategory->setKey('id')->setNestable()->setParent($usercategories);
+    $usercategory->setKey('id')->setNestable()->setParent($userpanel);
     $this->registerView($usercategory);
 
     $userimages = new RouterViewConfiguration('userimages');
@@ -143,7 +143,7 @@ class JG3ModernRouter extends DefaultRouter
     $this->registerView($userimages);
 
     $userimage = new RouterViewConfiguration('userimage');
-    $userimage->setKey('id')->setParent($userimages);
+    $userimage->setKey('id')->setParent($usercategory, 'catid');
     $this->registerView($userimage);
 
     $this->attachRule(new MenuRules($this));

--- a/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -158,7 +158,7 @@ class JG3ModernRouter extends DefaultRouter
   public function preprocess($query)
   {
     // Check for a controller.task command.
-    if(isset($query['task']) && \str_contains($query['task'], '.'))
+    if(isset($query['task']) && str_contains($query['task'], '.'))
     {
       [$view, $task] = explode('.', $query['task']);
 
@@ -200,7 +200,7 @@ class JG3ModernRouter extends DefaultRouter
     }
 
     // Process the parsed variables based on custom defined rules
-    foreach ($this->rules as $rule)
+    foreach($this->rules as $rule)
     {
       $rule->preprocess($query);
     }

--- a/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -179,7 +179,7 @@ class JG3ModernRouter extends DefaultRouter
       }
 
       if(isset($menuitem->query['view']) &&
-        \in_array($menuitem->query['view'], ['image', 'images'], true)
+        \in_array($menuitem->query['view'], ['image', 'categories'], true)
         )
       {
         // Set the Itemid if it has the correct type
@@ -188,7 +188,7 @@ class JG3ModernRouter extends DefaultRouter
       else
       {
         // Fetch a menuitem id of the correct type
-        $query['Itemid'] = JoomHelper::getMenuItem('images');
+        $query['Itemid'] = JoomHelper::getMenuItem('categories');
       }
     }
 
@@ -225,7 +225,7 @@ class JG3ModernRouter extends DefaultRouter
             return [0 => 'noimage'];
           }
 
-          return [0 => '0:noimage'];
+          return [0 => 'noimage:0'];
         }
         elseif($query['view'] = 'userimage')
         {
@@ -255,12 +255,12 @@ class JG3ModernRouter extends DefaultRouter
    * @param   string   $segment  Segment of the image to retrieve the ID for
    * @param   array    $query    The request that is parsed right now
    *
-   * @return  int   The id of this item or int 0
+   * @return  mixed    The id of this item or int 0
    * @since  4.0.0
    */
-  public function getImageId($segment, $query): int
+  public function getImageId($segment, $query)
   {
-    if($segment == '0-' || $segment == 'noimage' || $segment == '0-noimage')
+    if($segment == '-0' || $segment == 'noimage' || $segment == 'noimage-0')
     {
       // Special case: No image with id=0
       return 'null';

--- a/site/com_joomgallery/tmpl/usercategories/default.xml
+++ b/site/com_joomgallery/tmpl/usercategories/default.xml
@@ -6,18 +6,22 @@
     </message>
   </layout>
   <fields name="request">
-    <fieldset name="request"
-    >
-      <field
-        name="userNeedsSettings"
-        type="note"
-        label="COM_JOOMGALLERY_MENU_VIEW_USER_SITE_INFO"
-        description="COM_JOOMGALLERY_MENU_VIEW_USER_SITE_INFO_DESC"
-        readonly="true"
-        class="alert alert-info"
-      />
+    <fieldset name="request">
+      <field name="id"
+             type="hidden"
+             default="1"
+             value="1" >
+      </field>
+      <field name="userNeedsSettings"
+             type="note"
+             label="COM_JOOMGALLERY_MENU_VIEW_USER_SITE_INFO"
+             description="COM_JOOMGALLERY_MENU_VIEW_USER_SITE_INFO_DESC"
+             readonly="true"
+             class="alert alert-info" >
+      </field>
     </fieldset>
   </fields>
+
   <fields name="params">
     <fieldset name="basic">
       <field name="showTitle"

--- a/site/com_joomgallery/tmpl/userimages/default.php
+++ b/site/com_joomgallery/tmpl/userimages/default.php
@@ -68,7 +68,7 @@ $categoriesView = Route::_('index.php?option=com_joomgallery&view=usercategories
 
 // return to userImages;
 $returnURL       = base64_encode('index.php?option=com_joomgallery&view=userimages');
-$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&return=' . $returnURL);
+$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&id=0&return=' . $returnURL);
 
 $baseLink_ImageEdit    = 'index.php?option=com_joomgallery&task=userimage.edit&id=';
 $baseLink_ImagesFilter = 'index.php?option=com_joomgallery&view=userimages&filter_category=';

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -346,7 +346,7 @@ function displayUserButtons($returnURL)
 $uploadView      = Route::_('index.php?option=com_joomgallery&view=userupload');
 $imagesView      = Route::_('index.php?option=com_joomgallery&view=userimages');
 $categoriesView  = Route::_('index.php?option=com_joomgallery&view=usercategories');
-$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&return=' . $returnURL);
+$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&id=0&return=' . $returnURL);
 
 ?>
 <div>

--- a/site/com_joomgallery/tmpl/userupload/default.php
+++ b/site/com_joomgallery/tmpl/userupload/default.php
@@ -38,7 +38,7 @@ $imagesView     = Route::_('index.php?option=com_joomgallery&view=userimages');
 
 // return to userupload;
 $returnURL       = base64_encode('index.php?option=com_joomgallery&view=userupload');
-$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&return=' . $returnURL);
+$newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&layout=editCat&id=0&return=' . $returnURL);
 
 $config = $this->params['configs'];
 


### PR DESCRIPTION
This PR fixes a lot of issues regarding the frontend routing that came out when trying to fix issue #327.

The empty category image was just the tip of an iceberg. While trying to fix this, I discovered lots of bugs in the frontend router itroduced with PR https://github.com/JoomGalleryfriends/JoomGallery/pull/262.

This PR should fix all problems regarding SEF URLs and routing in the frontend.

## Important!
As soon as you create a menu item of type `User: User panel`, you also have to add a manu item of type `User: List categories` otherwise the router is not able to create the URLs correctly and you will get PHP warnings and broken links.

<img width="961" height="384" alt="grafik" src="https://github.com/user-attachments/assets/8b803090-7fd4-4091-a38c-51ed6eba362f" />

## How to test this PR

### Test 1
Navigate through the frontend. All views should work correctly, also with SEF URL's activated.

### Test 2
Try to reach the views in the userpanel by...
1. ... access directly via `index.php?option=com_joomgallery&view=userpanel`
2. ... create menu items of type `User: User panel` and `User: List categories` and access though them

### Test 3
Try with both Routers in the JoomGallery configurations
- `Modern Router (default)`
- `Modern Router (JG3 flavor)`
