### PR TITLE
Router: Specific noids param for images

### DIFF
--- a/administrator/com_joomgallery/forms/config.xml
+++ b/administrator/com_joomgallery/forms/config.xml
@@ -135,6 +135,17 @@
         <option value="1">JYES</option>
       </field>
 
+      <field name="jg_router_imgids"
+              type="radio"
+              default="0"
+              class="btn-group"
+              layout="joomla.form.field.radio.switcher"
+              label="COM_JOOMGALLERY_CONFIG_NOIMGIDS_LABEL"
+              description="COM_JOOMGALLERY_CONFIG_NOIMGIDS_LONG" >
+        <option value="0">JNO</option>
+        <option value="1">JYES</option>
+      </field>
+
       <field name="jg_compatibility_mode"
              type="list"
              global_only="true"

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -761,6 +761,8 @@ COM_JOOMGALLERY_CONFIG_CATEGORY_VIEW_BROWSE_IMAGES_LINK_OPT2="Link below the cat
 COM_JOOMGALLERY_CONFIG_CATEGORY_VIEW_DESCRIPTION_LABEL="Show label 'Description:'"
 COM_JOOMGALLERY_CONFIG_CATEGORY_VIEW_DESCRIPTION_LABEL_DESC="If enabled, it will display the label 'Description:' before the image description."
 COM_JOOMGALLERY_CONFIG_CATEGORY_SUBCATEGORIES_DESCRIPTION="Category Description"
+COM_JOOMGALLERY_CONFIG_NOIMGIDS_LABEL="Remove image IDs from URLs"
+COM_JOOMGALLERY_CONFIG_NOIMGIDS_LONG="Remove the IDs from the image URLs of this component."
 
 ;Services
 COM_JOOMGALLERY_SERVICE_READING_ERROR="Read image failed. No further processing."

--- a/administrator/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/com_joomgallery/sql/install.mysql.utf8.sql
@@ -126,6 +126,7 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_configs` (
 `jg_use_real_paths` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_router` VARCHAR(100) NOT NULL DEFAULT "DefaultRouter",
 `jg_router_ids` TINYINT(1) NOT NULL DEFAULT 0,
+`jg_router_imgids` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_compatibility_mode` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_replaceinfo` TEXT NOT NULL,
 `jg_replaceshowwarning` TINYINT(1) NOT NULL DEFAULT 0,

--- a/administrator/com_joomgallery/sql/updates/mysql/4.3.0.sql
+++ b/administrator/com_joomgallery/sql/updates/mysql/4.3.0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__joomgallery_configs` ADD `jg_router_imgids` TINYINT(1) NOT NULL DEFAULT 0 AFTER `jg_router_ids`;

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -75,6 +75,15 @@ class DefaultRouter extends RouterView
   private bool $noIDs;
 
   /**
+   * Param to use image ids in URLs
+   *
+   * @var    bool
+   *
+   * @since  4.3.0
+   */
+  private bool $noIMG_IDs;
+
+  /**
    * Database object
    *
    * @var    DatabaseInterface
@@ -100,8 +109,9 @@ class DefaultRouter extends RouterView
     parent::__construct($app, $menu);
 
     // Get router config value
-    $this->noIDs = (bool) $app->bootComponent('com_joomgallery')->getConfig()->get('jg_router_ids', '0');
-    $this->db    = $db;
+    $this->noIDs     = (bool) $app->bootComponent('com_joomgallery')->getConfig()->get('jg_router_ids', '0');
+    $this->noIMG_IDs = (bool) $app->bootComponent('com_joomgallery')->getConfig()->get('jg_router_imgids', '0');
+    $this->db        = $db;
 
     if($skipSelf)
     {
@@ -242,7 +252,7 @@ class DefaultRouter extends RouterView
         if($query['view'] = 'image' && $query['format'] = 'raw')
         {
           // Load the no-image
-          if($this->noIDs)
+          if($this->noIMG_IDs)
           {
             return [0 => 'noimage'];
           }
@@ -259,7 +269,7 @@ class DefaultRouter extends RouterView
       $id .= ':' . $this->getImageAliasDb($id);
     }
 
-    if($this->noIDs)
+    if($this->noIMG_IDs)
     {
       list($void, $segment) = explode(':', $id, 2);
 
@@ -286,7 +296,7 @@ class DefaultRouter extends RouterView
       $id .= ':' . $this->getImageAliasDb($id);
     }
 
-    if($this->noIDs)
+    if($this->noIMG_IDs)
     {
       list($void, $segment) = explode(':', $id, 2);
 
@@ -318,7 +328,7 @@ class DefaultRouter extends RouterView
       return $this->getImageSegment($id, $query);
     }
 
-    if($this->noIDs)
+    if($this->noIMG_IDs)
     {
       list($void, $segment) = explode(':', $id, 2);
 

--- a/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -62,15 +62,6 @@ class JG3ModernRouter extends DefaultRouter
   public static string $image_parentID = 'catid';
 
   /**
-   * Param to use ids in URLs
-   *
-   * @var    bool
-   *
-   * @since  4.0.0
-   */
-  private bool $noIDs;
-
-  /**
    * Database object
    *
    * @var    DatabaseInterface
@@ -79,22 +70,12 @@ class JG3ModernRouter extends DefaultRouter
    */
   private $db;
 
-  /**
-   * The category cache
-   *
-   * @var    array
-   *
-   * @since  4.0.0
-   */
-  private $categoryCache = [];
-
   public function __construct(SiteApplication $app, AbstractMenu $menu, ?CategoryFactoryInterface $categoryFactory, DatabaseInterface $db)
   {
     parent::__construct($app, $menu, $categoryFactory, $db, true);
 
     // Get router config value
-    $this->noIDs = (bool) $app->bootComponent('com_joomgallery')->getConfig()->get('jg_router_ids', '0');
-    $this->db    = $db;
+    $this->db = $db;
 
     $gallery = new RouterViewConfiguration('gallery');
     $this->registerView($gallery);
@@ -226,12 +207,6 @@ class JG3ModernRouter extends DefaultRouter
       {
         if($query['view'] = 'image' && $query['format'] = 'raw')
         {
-          // Load the no-image
-          if($this->noIDs)
-          {
-            return [0 => 'noimage'];
-          }
-
           return [0 => 'noimage:0'];
         }
         elseif($query['view'] = 'userimage')


### PR DESCRIPTION
During writing of the [Router documentation](https://www.joomgalleryfriends.net/dokumentation/konfiguration/der-moderne-router.html#guidelines) I realised again that how dramatic it is when turning of the IDs in the Router for images. Especially when using the `Modern Router (default)` which does not create URLs including the category structure.

If you want to create URLs like this
```index.php/gallery/images/5-flugzeug-2.html```
it is really important to have the IDs in the URLs even though it would make sense to remove them for everything else.

Therefore I added a second parameter in the JoomGallery configuration where the IDs in URLS just for images can be turned on and off separately to all the other content types like categories, users, collections, comments, tags, ...

So we end up having 5 JoomGallery specific params just for how SEF URLs should be created:
<img width="923" height="417" alt="grafik" src="https://github.com/user-attachments/assets/d840812b-7f04-4e5f-89a6-fcbb8ea2d2a5" />

### Note
The new parameter `Remove image IDs from URLs` should only has an effect on the `default` Router. As the `JG3 flavor` is designed to keep backward compatible URLs it keeps the ID in the URL anyway.
@MrMusic Is this correct? The JG3 always had the ID in the URL for images. It was not possible to remove them there?

## How to test this PR
Turn on and off the two params for removing IDs from URLs. Check the category and detail view in the frontend that they still work and that the URLs are reflecting what you configured.
Perform this test for the `default` as well as for the `JG3 flavor` Router.