### PR TITLE
Frontend: New category button fix

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Clean up unnecessary files
         run: |
-          rm -rf crowdin.yml composer.json composer.lock docs tests tools .github .editorconfig
+          rm -rf crowdin.yml composer.json composer.lock header.txt phpstan.neon ruleset.xml docs tests tools .github .editorconfig
 
       - name: Cleanup pel directory
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Clean up unnecessary files
         run: |
-          rm -rf crowdin.yml composer.json composer.lock docs tests .github .editorconfig
+          rm -rf crowdin.yml composer.json composer.lock docs tests tools .github .editorconfig
 
       - name: Cleanup pel directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
           tools: composer
 
       - name: Install dependencies
-        run: composer install --no-dev --prefer-dist
+        run: composer install --no-dev --no-scripts --prefer-dist --optimize-autoloader
 
       - name: Clean up unnecessary files
         run: |
-          rm -rf crowdin.yml composer.json composer.lock docs tests tools .github .editorconfig
+          rm -rf crowdin.yml composer.json composer.lock header.txt phpstan.neon ruleset.xml docs tests tools .github .editorconfig
 
       - name: Cleanup pel directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Clean up unnecessary files
         run: |
-          rm -rf crowdin.yml composer.json composer.lock docs tests .github .editorconfig
+          rm -rf crowdin.yml composer.json composer.lock docs tests tools .github .editorconfig
 
       - name: Cleanup pel directory
         run: |

--- a/administrator/com_joomgallery/layouts/joomgallery/migrepair.php
+++ b/administrator/com_joomgallery/layouts/joomgallery/migrepair.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/configlist.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/configlist.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/file.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/file.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/jgimage.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/jgimage.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/border.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/border.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/exif.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/exif.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/modal.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/section.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/section.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/sectionWithPopup.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/subform/repeatable-config/sectionWithPopup.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/field/value.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/field/value.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/form/renderfield.php
+++ b/administrator/com_joomgallery/layouts/joomla/form/renderfield.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/pagination/link.php
+++ b/administrator/com_joomgallery/layouts/joomla/pagination/link.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/joomla/pagination/links.php
+++ b/administrator/com_joomgallery/layouts/joomla/pagination/links.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/layouts/refresher.php
+++ b/administrator/com_joomgallery/layouts/refresher.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/CategoriesController.php
+++ b/administrator/com_joomgallery/src/Controller/CategoriesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/CategoryController.php
+++ b/administrator/com_joomgallery/src/Controller/CategoryController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/ConfigController.php
+++ b/administrator/com_joomgallery/src/Controller/ConfigController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/ConfigsController.php
+++ b/administrator/com_joomgallery/src/Controller/ConfigsController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/DisplayController.php
+++ b/administrator/com_joomgallery/src/Controller/DisplayController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/ImageController.php
+++ b/administrator/com_joomgallery/src/Controller/ImageController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/ImagesController.php
+++ b/administrator/com_joomgallery/src/Controller/ImagesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/JoomAdminController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomAdminController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/JoomFormController.php
+++ b/administrator/com_joomgallery/src/Controller/JoomFormController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/MigrationController.php
+++ b/administrator/com_joomgallery/src/Controller/MigrationController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/TagController.php
+++ b/administrator/com_joomgallery/src/Controller/TagController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/TagsController.php
+++ b/administrator/com_joomgallery/src/Controller/TagsController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/TaskController.php
+++ b/administrator/com_joomgallery/src/Controller/TaskController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Controller/TasksController.php
+++ b/administrator/com_joomgallery/src/Controller/TasksController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Extension/JoomCache.php
+++ b/administrator/com_joomgallery/src/Extension/JoomCache.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
+++ b/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
@@ -65,7 +65,7 @@ class JoomgalleryComponent extends MVCComponent implements BootableExtensionInte
   use AssociationServiceTrait;
   use HTMLRegistryAwareTrait;
   use RouterServiceTrait {
-RouterServiceTrait::createRouter as traitCreateRouter;
+    RouterServiceTrait::createRouter as traitCreateRouter;
   }
 
   /**
@@ -188,9 +188,8 @@ RouterServiceTrait::createRouter as traitCreateRouter;
       return $this->traitCreateRouter($application, $menu);
     }
 
-
-      // Use a legacy router
-      return new $router($application, $menu);
+    // Use a legacy router
+    return new $router($application, $menu);
   }
 
   /**
@@ -243,9 +242,9 @@ RouterServiceTrait::createRouter as traitCreateRouter;
     $language->load('com_joomgallery', JPATH_ADMINISTRATOR);
 
     return [
-      'com_joomgallery.image' => $language->_('COM_JOOMGALLERY_IMAGES'),
-      'com_joomgallery.category'    => $language->_('JCATEGORIES'),
-      'com_joomgallery.userimage' => $language->_('COM_JOOMGALLERY_IMAGES'),
+      'com_joomgallery.image'        => $language->_('COM_JOOMGALLERY_IMAGES'),
+      'com_joomgallery.category'     => $language->_('JCATEGORIES'),
+      'com_joomgallery.userimage'    => $language->_('COM_JOOMGALLERY_IMAGES'),
       'com_joomgallery.usercategory' => $language->_('JCATEGORIES'),
     ];
   }

--- a/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
+++ b/administrator/com_joomgallery/src/Extension/JoomgalleryComponent.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Extension/MessageTrait.php
+++ b/administrator/com_joomgallery/src/Extension/MessageTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Extension/ResponseTrait.php
+++ b/administrator/com_joomgallery/src/Extension/ResponseTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Extension/ServiceTrait.php
+++ b/administrator/com_joomgallery/src/Extension/ServiceTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Extension;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/ConfigsubformField.php
+++ b/administrator/com_joomgallery/src/Field/ConfigsubformField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/CreatedbyField.php
+++ b/administrator/com_joomgallery/src/Field/CreatedbyField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/CustomlistField.php
+++ b/administrator/com_joomgallery/src/Field/CustomlistField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/CustomradioField.php
+++ b/administrator/com_joomgallery/src/Field/CustomradioField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/CustomtextField.php
+++ b/administrator/com_joomgallery/src/Field/CustomtextField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/ExifusercommentField.php
+++ b/administrator/com_joomgallery/src/Field/ExifusercommentField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/ExternalconfigField.php
+++ b/administrator/com_joomgallery/src/Field/ExternalconfigField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/FilemultipleField.php
+++ b/administrator/com_joomgallery/src/Field/FilemultipleField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/ImgprocessorlistField.php
+++ b/administrator/com_joomgallery/src/Field/ImgprocessorlistField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgMenuitemTrait.php
+++ b/administrator/com_joomgallery/src/Field/JgMenuitemTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgcategoryField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategoryField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgimageField.php
+++ b/administrator/com_joomgallery/src/Field/JgimageField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgimagetypeField.php
+++ b/administrator/com_joomgallery/src/Field/JgimagetypeField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JglistField.php
+++ b/administrator/com_joomgallery/src/Field/JglistField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgnumberField.php
+++ b/administrator/com_joomgallery/src/Field/JgnumberField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgradioField.php
+++ b/administrator/com_joomgallery/src/Field/JgradioField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgtagField.php
+++ b/administrator/com_joomgallery/src/Field/JgtagField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgtaskField.php
+++ b/administrator/com_joomgallery/src/Field/JgtaskField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/JgtextField.php
+++ b/administrator/com_joomgallery/src/Field/JgtextField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/MetadatacommentField.php
+++ b/administrator/com_joomgallery/src/Field/MetadatacommentField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/ModifiedbyField.php
+++ b/administrator/com_joomgallery/src/Field/ModifiedbyField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/TimecreatedField.php
+++ b/administrator/com_joomgallery/src/Field/TimecreatedField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/TimeupdatedField.php
+++ b/administrator/com_joomgallery/src/Field/TimeupdatedField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Field/UserdropdownField.php
+++ b/administrator/com_joomgallery/src/Field/UserdropdownField.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Field;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Form/ConfigForm.php
+++ b/administrator/com_joomgallery/src/Form/ConfigForm.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Form;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Form/FormFactory.php
+++ b/administrator/com_joomgallery/src/Form/FormFactory.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Form;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Helper/ApprovedButton.php
+++ b/administrator/com_joomgallery/src/Helper/ApprovedButton.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Helper;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Helper/ConfigHelper.php
+++ b/administrator/com_joomgallery/src/Helper/ConfigHelper.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Helper;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Helper/FilesystemHelper.php
+++ b/administrator/com_joomgallery/src/Helper/FilesystemHelper.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Helper;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Helper;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/MVC/MVCFactory.php
+++ b/administrator/com_joomgallery/src/MVC/MVCFactory.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\MVC;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/MVC/MVCFactoryProvider.php
+++ b/administrator/com_joomgallery/src/MVC/MVCFactoryProvider.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\MVC;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Model/JoomAdminModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomAdminModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Model/JoomListModel.php
+++ b/administrator/com_joomgallery/src/Model/JoomListModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Router/RouterFactory.php
+++ b/administrator/com_joomgallery/src/Router/RouterFactory.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Router;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Router/RouterFactoryProvider.php
+++ b/administrator/com_joomgallery/src/Router/RouterFactoryProvider.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Router;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Access/Access.php
+++ b/administrator/com_joomgallery/src/Service/Access/Access.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Access;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Access/Base/AccessOwn.php
+++ b/administrator/com_joomgallery/src/Service/Access/Base/AccessOwn.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Access\Base;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Config/Config.php
+++ b/administrator/com_joomgallery/src/Service/Config/Config.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Config;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Config/DefaultConfig.php
+++ b/administrator/com_joomgallery/src/Service/Config/DefaultConfig.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Config;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Filesystem/Exception/AdapterNotFoundException.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Exception/AdapterNotFoundException.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem\Exception;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
+++ b/administrator/com_joomgallery/src/Service/Filesystem/Filesystem.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Filesystem;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GDtools.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/IMGtools/GifCreator.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GifCreator.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/IMGtools/GifFrameExtractor.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/GifFrameExtractor.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMGtools.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
+++ b/administrator/com_joomgallery/src/Service/IMGtools/IMtools.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\IMGtools;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Messenger/MailMessenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/MailMessenger.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Messenger/Messenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/Messenger.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Messenger/MessengerInterface.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/MessengerInterface.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
+++ b/administrator/com_joomgallery/src/Service/Messenger/PmMessenger.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Messenger;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Metadata/IptcDataEditor.php
+++ b/administrator/com_joomgallery/src/Service/Metadata/IptcDataEditor.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Metadata;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Metadata/Metadata.php
+++ b/administrator/com_joomgallery/src/Service/Metadata/Metadata.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Metadata;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Metadata/MetadataExifTool.php
+++ b/administrator/com_joomgallery/src/Service/Metadata/MetadataExifTool.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Metadata;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Metadata/MetadataPHP.php
+++ b/administrator/com_joomgallery/src/Service/Metadata/MetadataPHP.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Metadata;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Metadata/PelDataEditor.php
+++ b/administrator/com_joomgallery/src/Service/Metadata/PelDataEditor.php
@@ -20,7 +20,6 @@ use lsolesen\pel\PelFormat;
 use lsolesen\pel\PelIfd;
 use lsolesen\pel\PelTag;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/Checks.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Checks.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/Migration.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Migration.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/MigrationInterface.php
+++ b/administrator/com_joomgallery/src/Service/Migration/MigrationInterface.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Scripts/Jg3ToJg4.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration\Scripts;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/Targetinfo.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Targetinfo.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Migration/Type.php
+++ b/administrator/com_joomgallery/src/Service/Migration/Type.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/Refresher/Refresher.php
+++ b/administrator/com_joomgallery/src/Service/Refresher/Refresher.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\Refresher;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/TusServer/FileToolsService.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/FileToolsService.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Service/TusServer/Server.php
+++ b/administrator/com_joomgallery/src/Service/TusServer/Server.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Service\TusServer;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/Asset/AssetTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/Asset/AssetTableTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table\Asset;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/Asset/GlobalAssetTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/Asset/GlobalAssetTableTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table\Asset;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/Asset/MultipleAssetsTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/Asset/MultipleAssetsTableTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table\Asset;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/Asset/NoAssetTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/Asset/NoAssetTableTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table\Asset;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/CategoryTable.php
+++ b/administrator/com_joomgallery/src/Table/CategoryTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/CollectionTable.php
+++ b/administrator/com_joomgallery/src/Table/CollectionTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/CommentTable.php
+++ b/administrator/com_joomgallery/src/Table/CommentTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/ConfigTable.php
+++ b/administrator/com_joomgallery/src/Table/ConfigTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/FaultyTable.php
+++ b/administrator/com_joomgallery/src/Table/FaultyTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/ImageTable.php
+++ b/administrator/com_joomgallery/src/Table/ImageTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/ImagetypeTable.php
+++ b/administrator/com_joomgallery/src/Table/ImagetypeTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/JoomTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/JoomTableTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/MigrationTable.php
+++ b/administrator/com_joomgallery/src/Table/MigrationTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
+++ b/administrator/com_joomgallery/src/Table/MultipleAssetsTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/TagTable.php
+++ b/administrator/com_joomgallery/src/Table/TagTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/TaskTable.php
+++ b/administrator/com_joomgallery/src/Table/TaskTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/UserTable.php
+++ b/administrator/com_joomgallery/src/Table/UserTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/Table/VoteTable.php
+++ b/administrator/com_joomgallery/src/Table/VoteTable.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\Table;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/User/User.php
+++ b/administrator/com_joomgallery/src/User/User.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\User;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/User/UserFactory.php
+++ b/administrator/com_joomgallery/src/User/UserFactory.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\User;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Categories/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Categories;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Category/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Category/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Category;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Category/RawView.php
+++ b/administrator/com_joomgallery/src/View/Category/RawView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Category;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Config/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Config/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Config;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Configs/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Configs/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Configs;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Control/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Control/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Control;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Images/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Images/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Images;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/JoomGalleryView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Migration/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Migration/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Migration;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Tag/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tag/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Tag;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Tags/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tags/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Tags;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Task/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Task/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Task;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Tasks/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Tasks/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Tasks;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/src/View/Test/HtmlView.php
+++ b/administrator/com_joomgallery/src/View/Test/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Administrator\View\Test;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/categories/default.php
+++ b/administrator/com_joomgallery/tmpl/categories/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/categories/modal.php
+++ b/administrator/com_joomgallery/tmpl/categories/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/category/edit.php
+++ b/administrator/com_joomgallery/tmpl/category/edit.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/config/edit.php
+++ b/administrator/com_joomgallery/tmpl/config/edit.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/configs/default.php
+++ b/administrator/com_joomgallery/tmpl/configs/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/control/default.php
+++ b/administrator/com_joomgallery/tmpl/control/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/image/edit.php
+++ b/administrator/com_joomgallery/tmpl/image/edit.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/image/replace.php
+++ b/administrator/com_joomgallery/tmpl/image/replace.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/image/upload.php
+++ b/administrator/com_joomgallery/tmpl/image/upload.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/images/default.php
+++ b/administrator/com_joomgallery/tmpl/images/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/images/modal.php
+++ b/administrator/com_joomgallery/tmpl/images/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/migration/default.php
+++ b/administrator/com_joomgallery/tmpl/migration/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/migration/step1.php
+++ b/administrator/com_joomgallery/tmpl/migration/step1.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/migration/step2.php
+++ b/administrator/com_joomgallery/tmpl/migration/step2.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/migration/step3.php
+++ b/administrator/com_joomgallery/tmpl/migration/step3.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/migration/step4.php
+++ b/administrator/com_joomgallery/tmpl/migration/step4.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/tag/edit.php
+++ b/administrator/com_joomgallery/tmpl/tag/edit.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/tags/default.php
+++ b/administrator/com_joomgallery/tmpl/tags/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/task/edit.php
+++ b/administrator/com_joomgallery/tmpl/task/edit.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/task/select.php
+++ b/administrator/com_joomgallery/tmpl/task/select.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/tasks/default.php
+++ b/administrator/com_joomgallery/tmpl/tasks/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/administrator/com_joomgallery/tmpl/test/default.php
+++ b/administrator/com_joomgallery/tmpl/test/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/joomgallery.xml
+++ b/joomgallery.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="4.0" method="upgrade">
   <name>com_joomgallery</name>
-  <creationDate>2026-01-12</creationDate>
+  <creationDate>2026-01-20</creationDate>
   <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
   <license>GNU General Public License version 3 or later</license>
   <author>JoomGallery::ProjectTeam</author>
   <authorEmail>team@joomgalleryfriends.net</authorEmail>
   <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-  <version>4.3.0</version>
+  <version>4.3.0-rc1</version>
   <description>JoomGallery 4, a native gallery component for Joomla! 4.x, 5.x and 6.x</description>
   <namespace path="src">Joomgallery\Component\Joomgallery</namespace>
 
   <scriptfile>script.php</scriptfile>
 
-  <install> 
+  <install>
     <sql>
       <file driver="mysql" charset="utf8">sql/install.mysql.utf8.sql</file>
     </sql>
   </install>
-  <update> 
+  <update>
     <schemas>
       <schemapath type="mysql">sql/updates/mysql</schemapath>
     </schemas>
   </update>
-  <uninstall> 
+  <uninstall>
     <sql>
       <file driver="mysql" charset="utf8">sql/uninstall.mysql.utf8.sql</file>
     </sql>

--- a/joomgallery.xml
+++ b/joomgallery.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="4.0" method="upgrade">
-    <name>com_joomgallery</name>
-  <creationDate>2025-12-11</creationDate>
-    <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
-    <license>GNU General Public License version 3 or later</license>
-    <author>JoomGallery::ProjectTeam</author>
-    <authorEmail>team@joomgalleryfriends.net</authorEmail>
-    <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.3.0</version>
-    <description>JoomGallery 4, a native gallery component for Joomla! 4.x, 5.x and 6.x</description>
-    <namespace path="src">Joomgallery\Component\Joomgallery</namespace>
+  <name>com_joomgallery</name>
+  <creationDate>2026-01-12</creationDate>
+  <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
+  <license>GNU General Public License version 3 or later</license>
+  <author>JoomGallery::ProjectTeam</author>
+  <authorEmail>team@joomgalleryfriends.net</authorEmail>
+  <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
+  <version>4.3.0</version>
+  <description>JoomGallery 4, a native gallery component for Joomla! 4.x, 5.x and 6.x</description>
+  <namespace path="src">Joomgallery\Component\Joomgallery</namespace>
 
   <scriptfile>script.php</scriptfile>
 

--- a/plugins/console/joomconsole/joomconsole.xml
+++ b/plugins/console/joomconsole/joomconsole.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="console" version="4.0" method="upgrade">
   <name>PLG_CONSOLE_JOOMCONSOLE</name>
-  <creationDate>2025-10-27</creationDate>
-  <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
+  <creationDate>2025-01-12</creationDate>
+  <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
   <license>GNU General Public License version 3 or later</license>
   <author>JoomGallery::ProjectTeam</author>
   <authorEmail>team@joomgalleryfriends.net</authorEmail>
   <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-  <version>4.2.0</version>
+  <version>4.3.0</version>
   <description>PLG_CONSOLE_JOOMCONSOLE_XML_DESCRIPTION</description>
   <namespace path="src">Joomgallery\Plugin\Console\Joomconsole</namespace>
   

--- a/plugins/console/joomconsole/joomconsole.xml
+++ b/plugins/console/joomconsole/joomconsole.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="console" version="4.0" method="upgrade">
   <name>PLG_CONSOLE_JOOMCONSOLE</name>
-  <creationDate>2025-01-20</creationDate>
+  <creationDate>2026-01-20</creationDate>
   <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
   <license>GNU General Public License version 3 or later</license>
   <author>JoomGallery::ProjectTeam</author>

--- a/plugins/console/joomconsole/joomconsole.xml
+++ b/plugins/console/joomconsole/joomconsole.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="console" version="4.0" method="upgrade">
   <name>PLG_CONSOLE_JOOMCONSOLE</name>
-  <creationDate>2025-01-12</creationDate>
+  <creationDate>2025-01-20</creationDate>
   <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
   <license>GNU General Public License version 3 or later</license>
   <author>JoomGallery::ProjectTeam</author>
   <authorEmail>team@joomgalleryfriends.net</authorEmail>
   <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-  <version>4.3.0</version>
+  <version>4.3.0-rc1</version>
   <description>PLG_CONSOLE_JOOMCONSOLE_XML_DESCRIPTION</description>
   <namespace path="src">Joomgallery\Plugin\Console\Joomconsole</namespace>
-  
+
   <files>
     <folder>language</folder>
     <folder>services</folder>

--- a/plugins/privacy/joomgallery/joomgallery.xml
+++ b/plugins/privacy/joomgallery/joomgallery.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="privacy" version="4.0" method="upgrade">
     <name>plg_privacy_joomgallery</name>
-    <creationDate>2025-01-12</creationDate>
+    <creationDate>2025-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.3.0</version>
+    <version>4.3.0-rc1</version>
     <description>PLG_PRIVACY_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\Privacy\Joomgallery</namespace>
-    
+
     <files>
         <folder>language</folder>
         <folder>services</folder>

--- a/plugins/privacy/joomgallery/joomgallery.xml
+++ b/plugins/privacy/joomgallery/joomgallery.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="privacy" version="4.0" method="upgrade">
     <name>plg_privacy_joomgallery</name>
-    <creationDate>2025-10-27</creationDate>
-    <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
+    <creationDate>2025-01-12</creationDate>
+    <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
     <description>PLG_PRIVACY_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\Privacy\Joomgallery</namespace>
     

--- a/plugins/privacy/joomgallery/joomgallery.xml
+++ b/plugins/privacy/joomgallery/joomgallery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="privacy" version="4.0" method="upgrade">
     <name>plg_privacy_joomgallery</name>
-    <creationDate>2025-01-20</creationDate>
+    <creationDate>2026-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>

--- a/plugins/system/joomgallery/joomgallery.xml
+++ b/plugins/system/joomgallery/joomgallery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomgallery</name>
-    <creationDate>2025-01-20</creationDate>
+    <creationDate>2026-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>

--- a/plugins/system/joomgallery/joomgallery.xml
+++ b/plugins/system/joomgallery/joomgallery.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomgallery</name>
-    <creationDate>2025-01-12</creationDate>
+    <creationDate>2025-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.3.0</version>
+    <version>4.3.0-rc1</version>
     <description>PLG_SYSTEM_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\System\Joomgallery</namespace>
-    
+
     <files>
         <folder>forms</folder>
         <folder>language</folder>

--- a/plugins/system/joomgallery/joomgallery.xml
+++ b/plugins/system/joomgallery/joomgallery.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomgallery</name>
-    <creationDate>2025-10-27</creationDate>
-    <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
+    <creationDate>2025-01-12</creationDate>
+    <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
     <description>PLG_SYSTEM_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\System\Joomgallery</namespace>
     

--- a/plugins/system/joomowner/joomowner.xml
+++ b/plugins/system/joomowner/joomowner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomowner</name>
-    <creationDate>2025-01-20</creationDate>
+    <creationDate>2026-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>

--- a/plugins/system/joomowner/joomowner.xml
+++ b/plugins/system/joomowner/joomowner.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomowner</name>
-    <creationDate>2025-01-12</creationDate>
+    <creationDate>2025-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.3.0</version>
+    <version>4.3.0-rc1</version>
     <description>PLG_SYSTEM_JOOMOWNER_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\System\Joomowner</namespace>
-    
+
     <files>
         <folder>language</folder>
         <folder>services</folder>

--- a/plugins/system/joomowner/joomowner.xml
+++ b/plugins/system/joomowner/joomowner.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="4.0" method="upgrade">
     <name>plg_system_joomowner</name>
-    <creationDate>2025-10-27</creationDate>
-    <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
+    <creationDate>2025-01-12</creationDate>
+    <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
     <description>PLG_SYSTEM_JOOMOWNER_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\System\Joomowner</namespace>
     

--- a/plugins/task/joomgallery/joomgallery.xml
+++ b/plugins/task/joomgallery/joomgallery.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="task" method="upgrade">
     <name>plg_task_joomgallery</name>
-    <creationDate>2025-10-27</creationDate>
-    <copyright>2008 - 2025  JoomGallery::ProjectTeam</copyright>
+    <creationDate>2025-01-12</creationDate>
+    <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
     <description>PLG_TASK_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\Task\Joomgallery</namespace>
 

--- a/plugins/task/joomgallery/joomgallery.xml
+++ b/plugins/task/joomgallery/joomgallery.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="task" method="upgrade">
     <name>plg_task_joomgallery</name>
-    <creationDate>2025-01-12</creationDate>
+    <creationDate>2025-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>
     <authorEmail>team@joomgalleryfriends.net</authorEmail>
     <authorUrl>https://www.joomgalleryfriends.net/</authorUrl>
-    <version>4.3.0</version>
+    <version>4.3.0-rc1</version>
     <description>PLG_TASK_JOOMGALLERY_XML_DESCRIPTION</description>
     <namespace path="src">Joomgallery\Plugin\Task\Joomgallery</namespace>
 

--- a/plugins/task/joomgallery/joomgallery.xml
+++ b/plugins/task/joomgallery/joomgallery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="task" method="upgrade">
     <name>plg_task_joomgallery</name>
-    <creationDate>2025-01-20</creationDate>
+    <creationDate>2026-01-20</creationDate>
     <copyright>2008 - 2026  JoomGallery::ProjectTeam</copyright>
     <license>GNU General Public License version 3 or later</license>
     <author>JoomGallery::ProjectTeam</author>

--- a/script.php
+++ b/script.php
@@ -1463,7 +1463,11 @@ class com_joomgalleryInstallerScript extends InstallerScript
   {
     $msg = '';
 
-    if(strpos(end($new_version), 'dev'))
+    if( strpos(end($new_version), 'dev') ||
+        strpos(end($new_version), 'alpha') ||
+        strpos(end($new_version), 'beta') ||
+        strpos(end($new_version), 'rc')
+     )
     {
       // We are dealing with a development version (alpha or beta)
       $msg .= Text::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION');

--- a/site/com_joomgallery/layouts/joomla/form/field/configlist.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/configlist.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/field/jgcategory.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgcategory.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/field/jgimage.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgimage.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/field/jgtag.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/jgtag.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/radio/configbtns.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/field/subform/exif.php
+++ b/site/com_joomgallery/layouts/joomla/form/field/subform/exif.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/form/renderfield.php
+++ b/site/com_joomgallery/layouts/joomla/form/renderfield.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/pagination/link.php
+++ b/site/com_joomgallery/layouts/joomla/pagination/link.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/pagination/links.php
+++ b/site/com_joomgallery/layouts/joomla/pagination/links.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/layouts/joomla/searchtools/default.php
+++ b/site/com_joomgallery/layouts/joomla/searchtools/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/CategoriesController.php
+++ b/site/com_joomgallery/src/Controller/CategoriesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/CategoryController.php
+++ b/site/com_joomgallery/src/Controller/CategoryController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/DisplayController.php
+++ b/site/com_joomgallery/src/Controller/DisplayController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/ImageController.php
+++ b/site/com_joomgallery/src/Controller/ImageController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/ImagesController.php
+++ b/site/com_joomgallery/src/Controller/ImagesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/JoomBaseController.php
+++ b/site/com_joomgallery/src/Controller/JoomBaseController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/RoutingTrait.php
+++ b/site/com_joomgallery/src/Controller/RoutingTrait.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UsercategoriesController.php
+++ b/site/com_joomgallery/src/Controller/UsercategoriesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UsercategoryController.php
+++ b/site/com_joomgallery/src/Controller/UsercategoryController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UserimageController.php
+++ b/site/com_joomgallery/src/Controller/UserimageController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UserimagesController.php
+++ b/site/com_joomgallery/src/Controller/UserimagesController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UserpanelController.php
+++ b/site/com_joomgallery/src/Controller/UserpanelController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Controller/UseruploadController.php
+++ b/site/com_joomgallery/src/Controller/UseruploadController.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Controller;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Dispatcher/Dispatcher.php
+++ b/site/com_joomgallery/src/Dispatcher/Dispatcher.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Dispatcher;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/JoomItemModel.php
+++ b/site/com_joomgallery/src/Model/JoomItemModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UsercategoriesModel.php
+++ b/site/com_joomgallery/src/Model/UsercategoriesModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UsercategoryModel.php
+++ b/site/com_joomgallery/src/Model/UsercategoryModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UserimageModel.php
+++ b/site/com_joomgallery/src/Model/UserimageModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UserimagesModel.php
+++ b/site/com_joomgallery/src/Model/UserimagesModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UserpanelModel.php
+++ b/site/com_joomgallery/src/Model/UserpanelModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Model/UseruploadModel.php
+++ b/site/com_joomgallery/src/Model/UseruploadModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Model;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Service;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -413,7 +413,7 @@ class DefaultRouter extends RouterView
   {
     if(!strpos($id, ':'))
     {
-      if(!$id)
+      if(!$id || $id == 'null')
       {
         if($query['view'] = 'usercategory' && $query['layout'] = 'editCat')
         {

--- a/site/com_joomgallery/src/Service/JG3LegacyRoter.php
+++ b/site/com_joomgallery/src/Service/JG3LegacyRoter.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Service;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\Service;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Categories/HtmlView.php
+++ b/site/com_joomgallery/src/View/Categories/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Categories;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Category/HtmlView.php
+++ b/site/com_joomgallery/src/View/Category/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Category/JsonView.php
+++ b/site/com_joomgallery/src/View/Category/JsonView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Category/RawView.php
+++ b/site/com_joomgallery/src/View/Category/RawView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Gallery/HtmlView.php
+++ b/site/com_joomgallery/src/View/Gallery/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Gallery;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/GifView.php
+++ b/site/com_joomgallery/src/View/Image/GifView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/JpegView.php
+++ b/site/com_joomgallery/src/View/Image/JpegView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/JpgView.php
+++ b/site/com_joomgallery/src/View/Image/JpgView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/PngView.php
+++ b/site/com_joomgallery/src/View/Image/PngView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/RawView.php
+++ b/site/com_joomgallery/src/View/Image/RawView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Image/WebpView.php
+++ b/site/com_joomgallery/src/View/Image/WebpView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Image;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Images/HtmlView.php
+++ b/site/com_joomgallery/src/View/Images/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Images;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/JoomGalleryJsonView.php
+++ b/site/com_joomgallery/src/View/JoomGalleryJsonView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/JoomGalleryJsonView.php
+++ b/site/com_joomgallery/src/View/JoomGalleryJsonView.php
@@ -98,7 +98,11 @@ class JoomGalleryJsonView extends JsonView
     $this->component = $this->app->bootComponent(_JOOM_OPTION);
     $this->user      = $this->app->getIdentity();
 
-    if(strpos($this->component->version, 'dev'))
+    if( stripos($this->component->version, 'dev') ||
+        stripos($this->component->version, 'alpha') ||
+        stripos($this->component->version, 'beta') ||
+        stripos($this->component->version, 'rc')
+     )
     {
       // We are dealing with a development version (alpha or beta)
       $this->message = Text::_('COM_JOOMGALLERY_NOTE_DEVELOPMENT_VERSION');

--- a/site/com_joomgallery/src/View/Usercategory/HtmlView.php
+++ b/site/com_joomgallery/src/View/Usercategory/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Usercategory;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Userimage/HtmlView.php
+++ b/site/com_joomgallery/src/View/Userimage/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Userimage;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/src/View/Userimages/HtmlView.php
+++ b/site/com_joomgallery/src/View/Userimages/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomgallery\Component\Joomgallery\Site\View\Userimages;
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/categories/default.php
+++ b/site/com_joomgallery/tmpl/categories/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/categories/modal.php
+++ b/site/com_joomgallery/tmpl/categories/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/category/default.php
+++ b/site/com_joomgallery/tmpl/category/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/images/default.php
+++ b/site/com_joomgallery/tmpl/images/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/images/modal.php
+++ b/site/com_joomgallery/tmpl/images/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/usercategories/default.php
+++ b/site/com_joomgallery/tmpl/usercategories/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/usercategory/editcat.php
+++ b/site/com_joomgallery/tmpl/usercategory/editcat.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/userimage/editimg.php
+++ b/site/com_joomgallery/tmpl/userimage/editimg.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/userimage/replace.php
+++ b/site/com_joomgallery/tmpl/userimage/replace.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/userimages/default.php
+++ b/site/com_joomgallery/tmpl/userimages/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/userimages/modal.php
+++ b/site/com_joomgallery/tmpl/userimages/modal.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -8,7 +8,6 @@
  * *********************************************************************************
  */
 
-// No direct access
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects


### PR DESCRIPTION
This PR fixes the issue reported in PR #326 that the button `New Category` is not working when SEF URLs is activated.

With this PR the button is working.