### PR TITLE
Remove outdated files and folders from 4.2

### DIFF
--- a/script.php
+++ b/script.php
@@ -200,6 +200,23 @@ class com_joomgalleryInstallerScript extends InstallerScript
         Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_READ_XML_FILE'), 'note');
         Log::add(Text::_('COM_JOOMGALLERY_ERROR_READ_XML_FILE'), 8, 'joomgallery');
       }
+
+      // remove outdated files and folders from JG4 and newer
+      foreach($this->removeJGfolders() as $folder)
+      {
+        if(is_dir(Path::clean($folder)))
+        {
+          Folder::delete(Path::clean($folder));
+        }
+      }
+
+      foreach($this->removeJGfiles() as $file)
+      {
+        if(is_file(Path::clean($file)))
+        {
+          File::delete(Path::clean($file));
+        }
+      }
     }
 
     $this->new_code = $parent->getManifest()->version;
@@ -1601,6 +1618,44 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $files[] = JPATH_ADMINISTRATOR . '/cache/' . md5('https://www.en.joomgalleryfriends.net/components/com_newversion/rss/extensions2.rss') . '.spc';
     $files[] = JPATH_ADMINISTRATOR . '/cache/' . md5('https://www.joomgalleryfriends.net/components/com_newversion/rss/extensions3.rss') . '.spc';
     $files[] = JPATH_ADMINISTRATOR . '/cache/' . md5('https://www.en.joomgalleryfriends.net/components/com_newversion/rss/extensions3.rss') . '.spc';
+
+    return $files;
+  }
+
+  /**
+   * Detect old joomgallery folders (v4.0.0 and newer)
+   *
+   * @return  array|bool   List of folder paths or false if no folders detected
+   */
+  private function removeJGfolders()
+  {
+    $app = Factory::getApplication();
+
+    $folders = [
+      JPATH_ROOT . '/components/com_joomgallery/src/View/Categoryform',
+      JPATH_ROOT . '/components/com_joomgallery/src/View/Imageform',
+      JPATH_ROOT . '/components/com_joomgallery/tmpl/categoryform',
+      JPATH_ROOT . '/components/com_joomgallery/tmpl/imageform',
+    ];
+
+    return $folders;
+  }
+
+  /**
+   * Detect old joomgallery files (v4.0.0 and newer)
+   *
+   * @return  array|bool   List of file paths or false if no files detected
+   */
+  private function removeJGfiles()
+  {
+    $files = [
+      JPATH_ROOT . '/components/com_joomgallery/forms/categoryform.xml',
+      JPATH_ROOT . '/components/com_joomgallery/forms/imageform.xml',
+      JPATH_ROOT . '/components/com_joomgallery/src/Controller/CategoryformController.php',
+      JPATH_ROOT . '/components/com_joomgallery/src/Controller/ImageformController.php',
+      JPATH_ROOT . '/components/com_joomgallery/src/Model/CategoryformModel.php',
+      JPATH_ROOT . '/components/com_joomgallery/src/Model/ImageformModel.php',
+    ];
 
     return $files;
   }


### PR DESCRIPTION
In der JoomGallery 4.2 gibt es im Frontend Dateien und Ordner die es in der 4.3 nicht mehr gibt bzw. geben wird.
Beim einem Update auf die 4.3 werden diese alten Dateien nicht gelöscht und bleiben zurück. Deshalb erscheint z.B. der Menüeintrag "Create Category" obwohl der keine Funktion hat. Vermutlich werden sie auch zukünftig nicht mehr benötigt?
Dieser PR löscht die folgenden Dateien/Ordner unter `site/components/com_joomgallery`:
**Dateien**:
forms/categoryform.xml
forms/imageform.xml
src/Controller/CategoryformController.php
src/Controller/ImageformController.php
src/Model/CategoryformModel.php
src/Model/ImageformModel.php
**Ordner**:
src/View/Categoryform
src/View/Imageform
tmpl/categoryform
tmpl/imageform