### PR TITLE
Added Ordering of subcategories

### DIFF
--- a/site/com_joomgallery/forms/filter_categories.xml
+++ b/site/com_joomgallery/forms/filter_categories.xml
@@ -29,6 +29,10 @@
             <option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
             <option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
             <option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+            <option value="a.created_by ASC">COM_JOOMGALLERY_CREATEDBY_ASC</option>
+            <option value="a.created_by DESC">COM_JOOMGALLERY_CREATEDBY_DESC</option>
+            <option value="a.date ASC">JGLOBAL_CREATED_DATE_ASC</option>
+            <option value="a.date DESC">JGLOBAL_CREATED_DATE_DESC</option>
             <option value="img_count ASC">COM_JOOMGALLERY_IMAGES_ASC</option>
             <option value="img_count DESC">COM_JOOMGALLERY_IMAGES_DESC</option>
             <option value="parent_title ASC">COM_JOOMGALLERY_PARENT_CATEGORY_LABEL_ASC</option>

--- a/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/site/com_joomgallery/src/Model/CategoryModel.php
@@ -580,7 +580,12 @@ class CategoryModel extends JoomItemModel
     $listModel->setState('list.start', $catform_limitstart);
 
     // Apply ordering
-    $listModel->setState('list.fullordering', 'a.lft ASC');
+    $listModel->setState(
+      'list.fullordering',
+      $catform_list['fullordering']
+          ?? $params['configs']->get('jg_category_view_ord_images', 'a.lft ASC', 'string')
+    );
+
   }
 
   /**


### PR DESCRIPTION
### What this PR does

The category view already exposes sorting options for subcategories (ordering, title, owner, date),
but `CategoryModel` always overrides the selected ordering with `a.lft ASC`.

This PR fixes that behavior by respecting the selected `list[fullordering]` value and only falling
back to the configured default when no ordering is provided.

### Details

- Keeps nested set ordering (`a.lft`) as the default, as required for category trees
- Allows alternative sort modes (title, owner, date) when explicitly selected
- Uses existing configuration (`jg_category_view_ord_images`) as a fallback
- No changes to database structure
- Backward compatible

Code reviewed against Joomla list model behavior; unable to reproduce locally but change is limited to respecting existing filters.

Let me know if you prefer the ordering fallback to be handled differently.

solves:  Category view: Ordering of subcategories #346
