### PR TITLE
Show hidden markings in user panel

### DIFF
--- a/site/com_joomgallery/tmpl/usercategories/default.php
+++ b/site/com_joomgallery/tmpl/usercategories/default.php
@@ -309,6 +309,14 @@ $baseLink_ImagesFilter = 'index.php?option=com_joomgallery&view=userimages&filte
                           }
                           ?>
                         </a>
+                        <?php if($item->hidden === 1) : ?>
+                          <div class="small">
+                            <?php echo LayoutHelper::render('joomla.html.treeprefix', ['level' => $item->level]); ?>
+                            <span class="badge bg-secondary">
+                              <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                            </span>
+                          </div>
+                        <?php endif; ?>
                       <?php endif; ?>
                     </th>
 

--- a/site/com_joomgallery/tmpl/userimages/default.php
+++ b/site/com_joomgallery/tmpl/userimages/default.php
@@ -298,7 +298,7 @@ $canDelete = false;
                             <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
                           </span>
                         </div>
-                     <?php endif; ?>
+                      <?php endif; ?>
                     </th>
 
                     <td class="d-none d-lg-table-cell text-center">

--- a/site/com_joomgallery/tmpl/userimages/default.php
+++ b/site/com_joomgallery/tmpl/userimages/default.php
@@ -292,6 +292,13 @@ $canDelete = false;
                         }
                         ?>
                       </a>
+                      <?php if($item->hidden === 1) : ?>
+                        <div class="small">
+                          <span class="badge bg-secondary">
+                            <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                          </span>
+                        </div>
+                     <?php endif; ?>
                     </th>
 
                     <td class="d-none d-lg-table-cell text-center">

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -498,6 +498,13 @@ $newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&
                           }
                           ?>
                         </a>
+                        <?php if($item->hidden === 1) : ?>
+                          <div class="small">
+                            <span class="badge bg-secondary">
+                              <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                            </span>
+                          </div>
+                        <?php endif; ?>
                       </th>
 
                       <td class="d-none d-md-table-cell text-center">
@@ -713,6 +720,13 @@ $newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&
                           }
                           ?>
                         </a>
+                        <?php if($item->hidden === 1) : ?>
+                          <div class="small">
+                            <span class="badge bg-secondary">
+                              <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                            </span>
+                          </div>
+                        <?php endif; ?>
                       </th>
 
                       <td class="d-none d-lg-table-cell text-center">
@@ -976,6 +990,13 @@ $newCategoryView = Route::_('index.php?option=com_joomgallery&view=usercategory&
                           }
                           ?>
                         </a>
+                        <?php if($item->hidden === 1) : ?>
+                          <div class="small">
+                            <span class="badge bg-secondary">
+                              <?php echo Text::_('COM_JOOMGALLERY_HIDDEN'); ?>
+                            </span>
+                          </div>
+                        <?php endif; ?>
                       </th>
 
                       <td class="d-none d-lg-table-cell text-center">


### PR DESCRIPTION
In the backend, hidden categories and images are marked in the list views.
![lists-hidden](https://github.com/user-attachments/assets/71894b68-da63-4e2d-8f2c-e9208d880219)
The 'hidden' label is missing in the Frontend user panel for categories and images.
This PR adds the 'hidden' label to the user area in the frontend as well.