### PR TITLE
Indicate plugin group on install message

### DIFF
--- a/script.php
+++ b/script.php
@@ -1339,12 +1339,12 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
         if($result)
         {
-          $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_UNINSTALL_EXT', 'Plugin', $pluginName));
+          $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_UNINSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName));
         }
         else
         {
-          $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_UNINSTALL_EXT', 'Plugin', $pluginName), 'error');
-          Log::add(Text::sprintf('COM_JOOMGALLERY_ERROR_UNINSTALL_EXT', 'Plugin', $pluginName), 8, 'joomgallery');
+          $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_UNINSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName), 'error');
+          Log::add(Text::sprintf('COM_JOOMGALLERY_ERROR_UNINSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName), 8, 'joomgallery');
         }
       }
     }

--- a/script.php
+++ b/script.php
@@ -1168,12 +1168,12 @@ class com_joomgalleryInstallerScript extends InstallerScript
 
       if($result)
       {
-        $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_INSTALL_EXT', 'Plugin', $pluginName));
+        $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_SUCCESS_INSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName));
       }
       else
       {
-        $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_INSTALL_EXT', 'Plugin', $pluginName), 'error');
-        Log::add(Text::sprintf('COM_JOOMGALLERY_ERROR_INSTALL_EXT', 'Plugin', $pluginName), 8, 'joomgallery');
+        $app->enqueueMessage(Text::sprintf('COM_JOOMGALLERY_ERROR_INSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName), 'error');
+        Log::add(Text::sprintf('COM_JOOMGALLERY_ERROR_INSTALL_EXT', 'Plugin', $pluginGroup . '.' . $pluginName), 8, 'joomgallery');
       }
 
       $query


### PR DESCRIPTION
JG has several plugins with the same name. This PR changes the install message to prepend the group info 

**Test instruction:**

**Before:**
The install message shows following parts

Plugin with name oomconsole was installed successfully.
Plugin with name joomgallery was installed successfully.
Plugin with name joomgallery was installed successfully.
Plugin with name joomowner was installed successfully.
Plugin with name joomgallery was installed successfully.

**After:**
The install message shows following parts

Plugin with name console.joomconsole was installed successfully.
Plugin with name privacy.joomgallery was installed successfully.
Plugin with name system.joomgallery was installed successfully.
Plugin with name system.joomowner was installed successfully.
Plugin with name task.joomgallery was installed successfully.