### PR TITLE
Add module positions

### DIFF
--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -143,7 +143,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php // load modules on jg_cat_top ?>
 <?php $modules = ModuleHelper::getModules('jg_cat_top'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>
@@ -187,7 +187,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php // load modules on jg_cat_bef_subcat ?>
 <?php $modules = ModuleHelper::getModules('jg_cat_bef_subcat'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>
@@ -225,7 +225,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php // load modules on jg_cat_bef_images ?>
 <?php $modules = ModuleHelper::getModules('jg_cat_bef_images'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>
@@ -313,7 +313,7 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 <?php // load modules on jg_cat_bottom ?>
 <?php $modules = ModuleHelper::getModules('jg_cat_bottom'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -140,8 +140,8 @@ $canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category',
 $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id, $this->item->parent_id, $this->item->language, $this->getLayout()));
 ?>
 
-<?php // load modules on jg_cat_top ?>
-<?php $modules = ModuleHelper::getModules('jg_cat_top'); ?>
+<?php // load modules on jg_category_top ?>
+<?php $modules = ModuleHelper::getModules('jg_category_top'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
@@ -184,8 +184,8 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <p><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_NO_ELEMENTS') ?></p>
 <?php endif; ?>
 
-<?php // load modules on jg_cat_bef_subcat ?>
-<?php $modules = ModuleHelper::getModules('jg_cat_bef_subcat'); ?>
+<?php // load modules on jg_category_before_subcategories ?>
+<?php $modules = ModuleHelper::getModules('jg_category_before_subcategories'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
@@ -222,8 +222,8 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
 
 <?php endif; ?>
 
-<?php // load modules on jg_cat_bef_images ?>
-<?php $modules = ModuleHelper::getModules('jg_cat_bef_images'); ?>
+<?php // load modules on jg_category_before_images ?>
+<?php $modules = ModuleHelper::getModules('jg_category_before_images'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
@@ -310,8 +310,8 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   </div>
 <?php endif; ?>
 
-<?php // load modules on jg_cat_bottom ?>
-<?php $modules = ModuleHelper::getModules('jg_cat_bottom'); ?>
+<?php // load modules on jg_category_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_category_bottom'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>

--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -14,6 +14,7 @@
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -139,6 +140,21 @@ $canCheckin = $this->getAcl()->checkACL('editstate', 'com_joomgallery.category',
 $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id, $this->item->parent_id, $this->item->language, $this->getLayout()));
 ?>
 
+<?php // load modules on jg_cat_top ?>
+<?php $modules = ModuleHelper::getModules('jg_cat_top'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
+
 <?php // Category title ?>
 <?php if($this->item->parent_id > 0) : ?>
   <h2><?php echo Text::sprintf('COM_JOOMGALLERY_CATEGORY_TITLE', $this->escape($this->item->title)); ?></h2>
@@ -168,6 +184,21 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   <p><?php echo Text::_('COM_JOOMGALLERY_CATEGORY_NO_ELEMENTS') ?></p>
 <?php endif; ?>
 
+<?php // load modules on jg_cat_bef_subcat ?>
+<?php $modules = ModuleHelper::getModules('jg_cat_bef_subcat'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
+
 <?php // Subcategories ?>
 <?php if(\count($this->item->children->items) > 0 && ($this->item->id == 1 || $numb_subcategories > 0)) : ?>
   <?php if($this->item->parent_id > 0) : ?>
@@ -189,6 +220,21 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
     <?php echo $this->item->children->pagination->getListFooter(); ?>
   <?php endif; ?>
 
+<?php endif; ?>
+
+<?php // load modules on jg_cat_bef_images ?>
+<?php $modules = ModuleHelper::getModules('jg_cat_bef_images'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
 <?php endif; ?>
 
 <?php // Category ?>
@@ -262,6 +308,21 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
       <?php echo Text::_('COM_JOOMGALLERY_CATEGORY_VIEW_BROWSE_IMAGES'); ?>
     </a></p>
   </div>
+<?php endif; ?>
+
+<?php // load modules on jg_cat_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_cat_bottom'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
 <?php endif; ?>
 
 <script>

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -84,8 +84,8 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
     </div>
   <?php endif; ?>
 
-  <?php // load modules on jg_gal_top ?>
-  <?php $modules = ModuleHelper::getModules('jg_gal_top'); ?>
+  <?php // load modules on jg_gallery_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_gallery_top'); ?>
   <?php if(!empty($modules)) : ?>
     <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
@@ -143,8 +143,8 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
   <?php endif; ?>
 </div>
 
-<?php // load modules on jg_gal_bottom ?>
-<?php $modules = ModuleHelper::getModules('jg_gal_bottom'); ?>
+<?php // load modules on jg_gallery_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_gallery_bottom'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -12,6 +12,7 @@
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -83,6 +84,21 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
     </div>
   <?php endif; ?>
 
+  <?php // load modules on jg_gal_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_gal_top'); ?>
+  <?php if(!empty($modules)) : ?>
+    <?php foreach ($modules as $module) : ?>
+      <?php $moduleparams = json_decode($module->params, true); ?>
+      <div class="card">
+        <?php if($module->showtitle) : ?>
+          <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+          <?php echo $moduleheader; ?>
+        <?php endif; ?>
+        <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
+
   <div class="gallery-header">
     <?php echo HTMLHelper::_('content.prepare', $this->item->description, '', 'com_joomgallery.gallery'); ?>
   </div>
@@ -126,6 +142,21 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
     </div>
   <?php endif; ?>
 </div>
+
+<?php // load modules on jg_gal_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_gal_bottom'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
 
 <script>
   // Add event listener to images

--- a/site/com_joomgallery/tmpl/gallery/default.php
+++ b/site/com_joomgallery/tmpl/gallery/default.php
@@ -87,7 +87,7 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
   <?php // load modules on jg_gal_top ?>
   <?php $modules = ModuleHelper::getModules('jg_gal_top'); ?>
   <?php if(!empty($modules)) : ?>
-    <?php foreach ($modules as $module) : ?>
+    <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
       <div class="card">
         <?php if($module->showtitle) : ?>
@@ -146,7 +146,7 @@ $wa->addInlineScript($iniJS, ['position' => 'after'], [], ['com_joomgallery.joom
 <?php // load modules on jg_gal_bottom ?>
 <?php $modules = ModuleHelper::getModules('jg_gal_bottom'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -61,8 +61,8 @@ $metadata       = $metadataLayout->render($this->item->imgmetadata);
 $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 ?>
 
-<?php // load modules on jg_img_top ?>
-<?php $modules = ModuleHelper::getModules('jg_img_top'); ?>
+<?php // load modules on jg_image_top ?>
+<?php $modules = ModuleHelper::getModules('jg_image_top'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
@@ -97,8 +97,8 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
   <?php endif; ?>
 </figure>
 
-<?php // load modules on jg_img_bef_info ?>
-<?php $modules = ModuleHelper::getModules('jg_img_bef_info'); ?>
+<?php // load modules on jg_image_before_info ?>
+<?php $modules = ModuleHelper::getModules('jg_image_before_info'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
@@ -199,8 +199,8 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
     </table>
 </div>
 
-<?php // load modules on jg_img_bottom ?>
-<?php $modules = ModuleHelper::getModules('jg_img_bottom'); ?>
+<?php // load modules on jg_image_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_image_bottom'); ?>
 <?php if(!empty($modules)) : ?>
   <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -64,7 +64,7 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 <?php // load modules on jg_img_top ?>
 <?php $modules = ModuleHelper::getModules('jg_img_top'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>
@@ -100,7 +100,7 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 <?php // load modules on jg_img_bef_info ?>
 <?php $modules = ModuleHelper::getModules('jg_img_bef_info'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>
@@ -202,7 +202,7 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 <?php // load modules on jg_img_bottom ?>
 <?php $modules = ModuleHelper::getModules('jg_img_bottom'); ?>
 <?php if(!empty($modules)) : ?>
-  <?php foreach ($modules as $module) : ?>
+  <?php foreach($modules as $module) : ?>
     <?php $moduleparams = json_decode($module->params, true); ?>
     <div class="card">
       <?php if($module->showtitle) : ?>

--- a/site/com_joomgallery/tmpl/image/default.php
+++ b/site/com_joomgallery/tmpl/image/default.php
@@ -14,6 +14,7 @@
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
@@ -60,6 +61,21 @@ $metadata       = $metadataLayout->render($this->item->imgmetadata);
 $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
 ?>
 
+<?php // load modules on jg_img_top ?>
+<?php $modules = ModuleHelper::getModules('jg_img_top'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
+
 <?php if($show_title) : ?>
   <h2><?php echo $this->item->title; ?></h2>
 <?php endif; ?>
@@ -80,6 +96,21 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
     <figcaption class="figure-caption"><?php echo $this->item->description; ?></figcaption>
   <?php endif; ?>
 </figure>
+
+<?php // load modules on jg_img_bef_info ?>
+<?php $modules = ModuleHelper::getModules('jg_img_bef_info'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
 
 <?php // Image info and fields ?>
 <div class="item_fields">
@@ -167,6 +198,21 @@ $fields = FieldsHelper::getFields('com_joomgallery.image', $this->item);
         <?php endif; ?>
     </table>
 </div>
+
+<?php // load modules on jg_img_bottom ?>
+<?php $modules = ModuleHelper::getModules('jg_img_bottom'); ?>
+<?php if(!empty($modules)) : ?>
+  <?php foreach ($modules as $module) : ?>
+    <?php $moduleparams = json_decode($module->params, true); ?>
+    <div class="card">
+      <?php if($module->showtitle) : ?>
+        <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+        <?php echo $moduleheader; ?>
+      <?php endif; ?>
+      <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+    </div>
+  <?php endforeach; ?>
+<?php endif; ?>
 
 <script>
   window.onload = function () {

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -66,7 +66,7 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
   <?php // load modules on jg_upa_top ?>
   <?php $modules = ModuleHelper::getModules('jg_upa_top'); ?>
   <?php if(!empty($modules)) : ?>
-    <?php foreach ($modules as $module) : ?>
+    <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
       <div class="card">
         <?php if($module->showtitle) : ?>
@@ -142,7 +142,7 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
   <?php // load modules on jg_upa_bottom ?>
   <?php $modules = ModuleHelper::getModules('jg_upa_bottom'); ?>
   <?php if(!empty($modules)) : ?>
-    <?php foreach ($modules as $module) : ?>
+    <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
       <div class="card">
         <?php if($module->showtitle) : ?>

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -13,6 +13,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -61,6 +62,21 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
   <!--        method="post" name="adminForm" id="adminForm"-->
   <!--        novalidate aria-label="--><?php //echo Text::_('COM_JOOMGALLERY_USER_PANEL', true); ?><!--">-->
   <div class="jg jg-user-panel ">
+
+  <?php // load modules on jg_upa_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_upa_top'); ?>
+  <?php if(!empty($modules)) : ?>
+    <?php foreach ($modules as $module) : ?>
+      <?php $moduleparams = json_decode($module->params, true); ?>
+      <div class="card">
+        <?php if($module->showtitle) : ?>
+          <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+          <?php echo $moduleheader; ?>
+        <?php endif; ?>
+        <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
 
     <?php if($isShowTitle): ?>
       <h3><?php echo Text::_('COM_JOOMGALLERY_USER_PANEL'); ?></h3>
@@ -122,6 +138,21 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
 
     <?php endif; ?>
   </div>
+
+  <?php // load modules on jg_upa_bottom ?>
+  <?php $modules = ModuleHelper::getModules('jg_upa_bottom'); ?>
+  <?php if(!empty($modules)) : ?>
+    <?php foreach ($modules as $module) : ?>
+      <?php $moduleparams = json_decode($module->params, true); ?>
+      <div class="card">
+        <?php if($module->showtitle) : ?>
+          <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+          <?php echo $moduleheader; ?>
+        <?php endif; ?>
+        <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
 </div>
 
 <?php

--- a/site/com_joomgallery/tmpl/userpanel/default.php
+++ b/site/com_joomgallery/tmpl/userpanel/default.php
@@ -63,8 +63,8 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
   <!--        novalidate aria-label="--><?php //echo Text::_('COM_JOOMGALLERY_USER_PANEL', true); ?><!--">-->
   <div class="jg jg-user-panel ">
 
-  <?php // load modules on jg_upa_top ?>
-  <?php $modules = ModuleHelper::getModules('jg_upa_top'); ?>
+  <?php // load modules on jg_userpanel_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_userpanel_top'); ?>
   <?php if(!empty($modules)) : ?>
     <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
@@ -139,8 +139,8 @@ $returnURL = base64_encode('index.php?option=com_joomgallery&view=userpanel');
     <?php endif; ?>
   </div>
 
-  <?php // load modules on jg_upa_bottom ?>
-  <?php $modules = ModuleHelper::getModules('jg_upa_bottom'); ?>
+  <?php // load modules on jg_userpanel_bottom ?>
+  <?php $modules = ModuleHelper::getModules('jg_userpanel_bottom'); ?>
   <?php if(!empty($modules)) : ?>
     <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>

--- a/site/com_joomgallery/tmpl/userupload/default.php
+++ b/site/com_joomgallery/tmpl/userupload/default.php
@@ -105,7 +105,7 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
   <?php // load modules on jg_upl_top ?>
   <?php $modules = ModuleHelper::getModules('jg_upl_top'); ?>
   <?php if(!empty($modules)) : ?>
-    <?php foreach ($modules as $module) : ?>
+    <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
       <div class="card">
         <?php if($module->showtitle) : ?>
@@ -264,7 +264,7 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
   <?php // load modules on jg_upl_bottom ?>
   <?php $modules = ModuleHelper::getModules('jg_upl_bottom'); ?>
   <?php if(!empty($modules)) : ?>
-    <?php foreach ($modules as $module) : ?>
+    <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
       <div class="card">
         <?php if($module->showtitle) : ?>

--- a/site/com_joomgallery/tmpl/userupload/default.php
+++ b/site/com_joomgallery/tmpl/userupload/default.php
@@ -13,6 +13,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
@@ -101,6 +102,21 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
 ?>
 
 <div>
+  <?php // load modules on jg_upl_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_upl_top'); ?>
+  <?php if(!empty($modules)) : ?>
+    <?php foreach ($modules as $module) : ?>
+      <?php $moduleparams = json_decode($module->params, true); ?>
+      <div class="card">
+        <?php if($module->showtitle) : ?>
+          <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+          <?php echo $moduleheader; ?>
+        <?php endif; ?>
+        <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
+
   <form class="jg jg-upload"
         action="<?php echo $uploadView; ?>"
         method="post" enctype="multipart/form-data" name="adminForm" id="adminForm" class="needs-validation"
@@ -244,6 +260,21 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
   </form>
 
   <div id="popup-area"></div>
+
+  <?php // load modules on jg_upl_bottom ?>
+  <?php $modules = ModuleHelper::getModules('jg_upl_bottom'); ?>
+  <?php if(!empty($modules)) : ?>
+    <?php foreach ($modules as $module) : ?>
+      <?php $moduleparams = json_decode($module->params, true); ?>
+      <div class="card">
+        <?php if($module->showtitle) : ?>
+          <?php $moduleheader = '<' . $moduleparams['header_tag'] . ' class="card-header ' . $moduleparams['header_class'] . '">' . htmlspecialchars($module->title) . '</' . $moduleparams['header_tag'] . '>'; ?>
+          <?php echo $moduleheader; ?>
+        <?php endif; ?>
+        <?php echo ModuleHelper::renderModule($module, ['style' => 'none']); ?>
+      </div>
+    <?php endforeach; ?>
+  <?php endif; ?>
 
 </div>
 

--- a/site/com_joomgallery/tmpl/userupload/default.php
+++ b/site/com_joomgallery/tmpl/userupload/default.php
@@ -102,8 +102,8 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
 ?>
 
 <div>
-  <?php // load modules on jg_upl_top ?>
-  <?php $modules = ModuleHelper::getModules('jg_upl_top'); ?>
+  <?php // load modules on jg_userupload_top ?>
+  <?php $modules = ModuleHelper::getModules('jg_userupload_top'); ?>
   <?php if(!empty($modules)) : ?>
     <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>
@@ -261,8 +261,8 @@ if($this->isUserLoggedIn && $this->isUserHasCategory)
 
   <div id="popup-area"></div>
 
-  <?php // load modules on jg_upl_bottom ?>
-  <?php $modules = ModuleHelper::getModules('jg_upl_bottom'); ?>
+  <?php // load modules on jg_userupload_bottom ?>
+  <?php $modules = ModuleHelper::getModules('jg_userupload_bottom'); ?>
   <?php if(!empty($modules)) : ?>
     <?php foreach($modules as $module) : ?>
       <?php $moduleparams = json_decode($module->params, true); ?>


### PR DESCRIPTION
This PR adds module positions for the most frontend views. 
The following module positions are available:
Module position | view | location
-- | -- | --
jg_gallery_top | Gallery view | top
jg_gallery_bottom | Gallery view | bottom
  |   |  
jg_category_top | Category view | top
jg_category_before_subcategories| Category view | before subcategories
jg_category_before_images | Category view | before images
jg_category_bottom | Category view | bottom
  |   |  
jg_image_top | single image view | top
jg_image_before_info | single image view | before image informations
jg_image_bottom | single image view | bottom
  |   |  
jg_userpanel_top | User panel | top
jg_userpanel_bottom | User panel | bottom
  |   |  
jg_userupload_top | Upload view | top
jg_userupload_bottom | Upload view | bottom

The module positions should be included in the documentation.

### How to test this PR

Install PR
Add different modules to the module positions
Test with different settings in module (some in advanced tab):
Title on/off
Header Tag h1-h6
add own css classes
...