### PR TITLE
Feature: Add hits counter

### DIFF
--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -112,6 +112,14 @@ class RawView extends JoomGalleryView
       $this->app->redirect(Route::_('index.php', false), 404);
     }
 
+    // Increment hits counter
+    $record_hits = (bool) $this->component->getConfig()->get('jg_record_hits', 1);
+    $record_hits_select = (array) $this->component->getConfig()->get('jg_record_hits_select');
+    if($record_hits && \in_array($type, $record_hits_select))
+    {
+      $model->hit();
+    }
+
     // Set mime encoding to document
     $this->getDocument()->setMimeEncoding($file_info->mime_type);
 

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -113,8 +113,9 @@ class RawView extends JoomGalleryView
     }
 
     // Increment hits counter
-    $record_hits = (bool) $this->component->getConfig()->get('jg_record_hits', 1);
+    $record_hits        = (bool) $this->component->getConfig()->get('jg_record_hits', 1);
     $record_hits_select = (array) $this->component->getConfig()->get('jg_record_hits_select');
+
     if($record_hits && \in_array($type, $record_hits_select))
     {
       $model->hit();


### PR DESCRIPTION
This Pull Request adds the counter for hits. The counter is counting up everytime an image type is requested.

You can configure which imge types are counted using the **Record Hits** and **Select imagetypes** in:
Configs -> Frontend Views -> Common Settings

### How to test this PR
- Disable SEF URLs in Joomla Configuration
- Open the database in something like phpMyAdmin and watch the **#__joomgallery.hits** row.
- Open a new browser tab and navigate to images using this kind of URLs:
`index.php?option=com_joomgallery&view=image&id=3&format=raw&type=detail`
- Switch between different image types

Check if the JoomGallery configurations `Record Hits` and `Select imagetypes` are correctly taken care.