### PR TITLE
Improve image loading handling in default_cat.php

### DIFF
--- a/site/com_joomgallery/tmpl/category/default_cat.php
+++ b/site/com_joomgallery/tmpl/category/default_cat.php
@@ -264,13 +264,29 @@ $returnURL  = base64_encode(JoomHelper::getViewRoute('category', $this->item->id
   </div>
 <?php endif; ?>
 
-<script>
-  // Add event listener to images
-  let loadImg = function() {
-    this.closest('.jg-image').classList.add('loaded');
-  }
-  let images = Array.from(document.getElementsByClassName('jg-image-thumb'));
-  images.forEach(image => {
-    image.addEventListener('load', loadImg);
-  });
+<script type="text/javascript">
+  (function() {
+    const loadImg = function (img) {
+      const container = img.closest('.jg-image');
+      if (container) {
+        container.classList.add('loaded');
+      }
+    };
+
+    const images = Array.from(document.getElementsByClassName('jg-image-thumb'));
+    images.forEach(image => {
+      // Check if image is already loaded (from cache or CDN)
+      if (image.complete && image.naturalHeight !== 0) {
+        loadImg(image);
+      } else {
+        image.addEventListener('load', function() {
+          loadImg(this);
+        });
+        // Optional: Error handling to show container even if image fails
+        image.addEventListener('error', function() {
+          loadImg(this);
+        });
+      }
+    });
+  })();
 </script>


### PR DESCRIPTION
This PR refactors the image loading logic to ensure that the .loaded class is correctly applied to image containers, even when images are loaded nearly instantaneously from a browser cache or CDN.

By checking the image.complete property, we can trigger the visibility logic manually if the load event has already fired before the event listener was registered. Additionally, I have added an error handler to ensure the container is still displayed if an image fails to load, preventing broken layouts.

Notes:
Please note that this implementation might not cover every single edge case across all environments, but it has been tested and is working correctly on my side. I would appreciate further review to ensure it aligns with the project's standards.

Fixes #367