### PR TITLE
Prevent blocking due to a missing user_agent

### DIFF
--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Version;
 use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
@@ -1096,6 +1097,14 @@ class JoomHelper
    */
   public static function fetchXML(string $uri): \SimpleXMLElement
   {
+
+    // Check for user_agent in php.ini
+    if(!ini_get('user_agent'))
+    {
+      $version = new Version();
+      ini_set('user_agent', $version->getUserAgent('Joomla', true, false));
+    }
+
     // Create the XMLReader object.
     $reader = new \XMLReader();
 

--- a/administrator/com_joomgallery/src/Helper/JoomHelper.php
+++ b/administrator/com_joomgallery/src/Helper/JoomHelper.php
@@ -1099,7 +1099,7 @@ class JoomHelper
   {
 
     // Check for user_agent in php.ini
-    if(!ini_get('user_agent'))
+    if(!\ini_get('user_agent'))
     {
       $version = new Version();
       ini_set('user_agent', $version->getUserAgent('Joomla', true, false));


### PR DESCRIPTION
The JoomGallery Control Panel displays a list of 'official JoomGallery extensions'. Currently, no 'user_agent' is sent to the web server when data is retrieved from the xml file. Due to the absence of the 'user_agent', the current IP address may be blocked.
This problem occurs primarily in local development environments, as a default value for user_agent is not usually set in the php.ini file.

This PR sets the value of 'user_agent' to Joomla's default value, provided that no value has been set in php.ini.