### PR TITLE
[Bug] JgcategorydropdownField

### DIFF
--- a/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
+++ b/administrator/com_joomgallery/src/Field/JgcategorydropdownField.php
@@ -117,9 +117,9 @@ class JgcategorydropdownField extends ListField
       $this->allowAdd     = isset($this->element['allowAdd']) ? (bool) $this->element['allowAdd'] : false;
       $this->customPrefix = (string) $this->element['customPrefix'];
 
-      $this->isCategoriesOfUser  = isset($this->element['categoriesOfUser']) ? (bool) $this->element['categoriesOfUser'] : false;
-      $this->isShow_NoParent     = isset($this->element['show_NoParent']) ? (bool) $this->element['show_NoParent'] : false;
-      $this->isShow_SelectHeader = isset($this->element['showSelect']) ? (bool) $this->element['showSelect'] : false;
+      $this->isCategoriesOfUser  = isset($this->element['categoriesOfUser']) ? filter_var($this->element['categoriesOfUser'], FILTER_VALIDATE_BOOLEAN) : false;
+      $this->isShow_NoParent     = isset($this->element['show_NoParent']) ? filter_var($this->element['show_NoParent'], FILTER_VALIDATE_BOOLEAN) : false;
+      $this->isShow_SelectHeader = isset($this->element['showSelect']) ? filter_var($this->element['showSelect'], FILTER_VALIDATE_BOOLEAN) : false;
 
       $elementOrdering = $this->element['ordering'] ?? '';
 

--- a/site/com_joomgallery/forms/usercategory.xml
+++ b/site/com_joomgallery/forms/usercategory.xml
@@ -62,7 +62,7 @@
            categoriesOfUser="true"
            default="1"
            show_root="false"
-           show_NoParent="true"
+           show_NoParent="false"
            message="COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY"/>
 
     <field name="published"

--- a/site/com_joomgallery/forms/usercategory.xml
+++ b/site/com_joomgallery/forms/usercategory.xml
@@ -62,7 +62,7 @@
            categoriesOfUser="true"
            default="1"
            show_root="false"
-           show_NoParent="false"
+           show_NoParent="true"
            message="COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY"/>
 
     <field name="published"


### PR DESCRIPTION
While looking for a quick fix for issue #377, I tried making changes to the `site/com_joomgallery/forms/usercategory.xml ` file to hide the parent categories. In doing so, I noticed that `show_NoParent=“false”` is being ignored. With the help of Claude AI, I was able to pinpoint the error in `administrator/com_joomgallery/src/Field/JgcategorydropdownField.php`. Now, when I set “Create” to “allowed” in the JoomGallery ACL, I can, as intended, only create subdirectories within my own categories. While this doesn’t fix the ACL bug, it is a legitimate workaround. 

@ThomasFinnern what do you think?