### PR TITLE
[4.4.0] Fix Hits counter

### DIFF
--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -113,12 +113,15 @@ class RawView extends JoomGalleryView
     }
 
     // Increment hits counter
-    $record_hits        = (bool) $this->component->getConfig()->get('jg_record_hits', 1);
-    $record_hits_select = (array) $this->component->getConfig()->get('jg_record_hits_select');
-
-    if($record_hits && \in_array($type, $record_hits_select))
+    if($this->app->isClient('site'))
     {
-      $model->hit();
+      $record_hits        = (bool) $this->component->getConfig()->get('jg_record_hits', 1);
+      $record_hits_select = (array) $this->component->getConfig()->get('jg_record_hits_select');
+
+      if($record_hits && \in_array($type, $record_hits_select))
+      {
+        $model->hit();
+      }
     }
 
     // Set mime encoding to document


### PR DESCRIPTION
Fix for Issue https://github.com/JoomGalleryfriends/JoomGallery/issues/378

Fixes:
1. The image is not displayed in the backend when the hit counter is enabled.
2. Hits should only be counted when the image is displayed in the frontend.