### PR TITLE
Fix text color in modal buttons

### DIFF
--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -46,6 +46,7 @@ img.jg-controlpanel-logo {
 }
 .admin .modal .btn-primary {
   background-color: var(--btn-primary-bg) !important;
+  color: var(--white) !important;
 }
 .modal .btn-secondary {
   color: var(--white) !important;

--- a/media/com_joomgallery/css/admin.css
+++ b/media/com_joomgallery/css/admin.css
@@ -46,7 +46,7 @@ img.jg-controlpanel-logo {
 }
 .admin .modal .btn-primary {
   background-color: var(--btn-primary-bg) !important;
-  color: var(--white) !important;
+  color: var(--btn-primary-color) !important;
 }
 .modal .btn-secondary {
   color: var(--white) !important;


### PR DESCRIPTION
In backend modals, the buttons have a text color that is difficult to read, e.g. in Configuration -> 'Edit Note' or 'Import Config-set'.
This PR changes the text color to white for better contrast.