### PR TITLE
Bugfix: Image metadata

### DIFF
--- a/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
+++ b/administrator/com_joomgallery/src/Service/Uploader/Uploader.php
@@ -259,7 +259,7 @@ abstract class Uploader implements UploaderInterface
     $metadata = $this->component->getMetadata()->readMetadata($this->src_file);
 
     // Add image metadata to data
-    $data['imgmetadata'] = json_encode($metadata);
+    $data['imgmetadata'] = json_encode($metadata, JSON_INVALID_UTF8_SUBSTITUTE);
 
     // Check if there is something to override
     if(!property_exists($this->component->getConfig()->get('jg_replaceinfo'), 'jg_replaceinfo0'))


### PR DESCRIPTION
Some cameras are storing info in the EXIF metadata which are binary and thus not UTF-8 compatible. This resulted in no metadata being stored.
With this PR applied, metadata should be stored again.

### How to test this PR
The Bug for example was there for images taken by an iPhone. So before this PR applied, no metadata was stored when uploading a iPhone image.
After applying this PR iPhone images should have metadata.