### PR TITLE
[Bugfix] Raw & Json endpoints

### DIFF
--- a/administrator/com_joomgallery/src/View/Category/RawView.php
+++ b/administrator/com_joomgallery/src/View/Category/RawView.php
@@ -15,8 +15,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Category;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
-use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
-use Joomla\CMS\Router\Route;
+use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryRawView;
 use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
 
 /**
@@ -25,7 +24,7 @@ use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
  * @package JoomGallery
  * @since   4.0.0
  */
-class RawView extends JoomGalleryView
+class RawView extends JoomGalleryRawView
 {
   /**
    * Raw view display method, outputs one image
@@ -58,24 +57,14 @@ class RawView extends JoomGalleryView
     // Get image resource
     try
     {
-      list($file_info, $ressource) = $this->component->getFilesystem()->getResource($img_path);
+      list($file_info, $resource) = $this->component->getFilesystem()->getResource($img_path);
     }
     catch (InvalidPathException $e)
     {
-      $this->app->enqueueMessage($e, 'error');
-      $this->app->redirect(Route::_('index.php', false), 404);
+      $this->outputError(404, $e->getMessage());
     }
 
-    // Set mime encoding
-    $this->getDocument()->setMimeEncoding($file_info->mime_type);
-
-    // Set header to specify the file name
-    $this->app->setHeader('Cache-Control', 'no-cache, must-revalidate');
-    $this->app->setHeader('Pragma', 'no-cache');
-    $this->app->setHeader('Content-disposition', 'inline; filename=' . basename($img_path));
-    $this->app->setHeader('Content-Length', \strval($file_info->size));
-
-    ob_end_clean(); //required here or large files will not work
-    fpassthru($ressource);
+    // Output
+    $this->outputResource($resource, $file_info->mime_type, $img_path, $file_info->size);
   }
 }

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -16,7 +16,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomgallery\Component\Joomgallery\Administrator\Model\ImageModel;
-use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
+use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryRawView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
 
@@ -26,7 +26,7 @@ use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
  * @package JoomGallery
  * @since   4.0.0
  */
-class RawView extends JoomGalleryView
+class RawView extends JoomGalleryRawView
 {
   /**
    * Raw view display method, outputs one image
@@ -56,7 +56,7 @@ class RawView extends JoomGalleryView
     // Check access
     if(!$this->access($id, $type))
     {
-      $this->app->redirect(Route::_('index.php', false), 403);
+      $this->outputError(403, Text::_('COM_JOOMGALLERY_ERROR_IMAGE_ACCESS_DENIED'));
     }
 
     /** @var ImageModel $model */
@@ -124,21 +124,8 @@ class RawView extends JoomGalleryView
       }
     }
 
-    // Set mime encoding to document
-    $this->getDocument()->setMimeEncoding($file_info->mime_type);
-
-    // Set header to specify the file name
-    $this->app->setHeader('Content-Type', $file_info->mime_type);
-    $this->app->setHeader('Content-Disposition', 'inline; filename=' . basename($img_path));
-    $this->app->setHeader('Content-Length', \strval($file_info->size));
-    $this->app->setHeader('Cache-Control', 'no-cache, must-revalidate');
-    $this->app->setHeader('Pragma', 'no-cache');
-
-    // Required for large files to work properly
-    if(ob_get_level() > 0) ob_end_clean();
-
-    fpassthru($resource);
-    fclose($resource);
+    // Output
+    $this->outputResource($resource, $file_info->mime_type, $img_path, $file_info->size);
   }
 
   /**

--- a/administrator/com_joomgallery/src/View/Image/RawView.php
+++ b/administrator/com_joomgallery/src/View/Image/RawView.php
@@ -17,7 +17,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\View\Image;
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomgallery\Component\Joomgallery\Administrator\Model\ImageModel;
 use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryRawView;
-use Joomla\CMS\Router\Route;
+use Joomla\CMS\Language\Text;
 use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
 
 /**
@@ -56,7 +56,7 @@ class RawView extends JoomGalleryRawView
     // Check access
     if(!$this->access($id, $type))
     {
-      $this->outputError(403, Text::_('COM_JOOMGALLERY_ERROR_IMAGE_ACCESS_DENIED'));
+      $this->outputError(403, Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'));
     }
 
     /** @var ImageModel $model */
@@ -99,8 +99,7 @@ class RawView extends JoomGalleryRawView
     }
     catch (InvalidPathException $e)
     {
-      $this->app->enqueueMessage($e, 'error');
-      $this->app->redirect(Route::_('index.php', false), 404);
+      $this->outputError(404, $e->getMessage());
     }
 
     // Create config service
@@ -109,7 +108,7 @@ class RawView extends JoomGalleryRawView
     // Postprocessing of the image
     if(!$this->ppImage($file_info, $resource, $type))
     {
-      $this->app->redirect(Route::_('index.php', false), 404);
+      $this->outputError(404, 'Error postprocessing the image');
     }
 
     // Increment hits counter

--- a/administrator/com_joomgallery/src/View/JoomGalleryJsonView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryJsonView.php
@@ -8,7 +8,7 @@
  * *********************************************************************************
  */
 
-namespace Joomgallery\Component\Joomgallery\Site\View;
+namespace Joomgallery\Component\Joomgallery\Administrator\View;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') || die;
@@ -94,7 +94,7 @@ class JoomGalleryJsonView extends JsonView
   {
     parent::__construct($config);
 
-    $this->app       = Factory::getApplication('administrator');
+    $this->app       = Factory::getApplication();
     $this->component = $this->app->bootComponent(_JOOM_OPTION);
     $this->user      = $this->app->getIdentity();
 
@@ -140,6 +140,82 @@ class JoomGalleryJsonView extends JsonView
   }
 
   /**
+   * Recursively converts all JSON strings in an object/array into PHP objects.
+   * Suitable for preparing a stdClass before calling json_encode().
+   *
+   * @param  mixed  $data  The data to be processed
+   *
+   * @return mixed
+   */
+  protected function prepareForJson(mixed $data): mixed
+  {
+    // Process objects
+    if(\is_object($data))
+    {
+      foreach($data as $key => $value)
+      {
+        $data->$key = $this->prepareForJson($value);
+      }
+
+      return $data;
+    }
+
+    // Process arrays
+    if(\is_array($data))
+    {
+      foreach($data as $key => $value)
+      {
+        $data[$key] = $this->prepareForJson($value);
+      }
+
+      return $data;
+    }
+
+    // Process strings
+    if(\is_string($data))
+    {
+      $trimmed = trim($data);
+
+      // Skip empty strings
+      if($trimmed === '')
+      {
+        return $data;
+      }
+
+      // Only attempt to decode values that look like JSON
+      if( ($trimmed[0] === '{' && str_ends_with($trimmed, '}')) || ($trimmed[0] === '[' && str_ends_with($trimmed, ']')))
+      {
+        try
+        {
+          $decoded = json_decode($trimmed, false, 512, JSON_THROW_ON_ERROR);
+
+          // Continue recursively because the decoded object may itself
+          // contain JSON strings.
+          return $this->prepareForJson($decoded);
+        }
+        catch(\JsonException)
+        {
+          // Not valid JSON -> leave untouched.
+        }
+      }
+    }
+
+    return $data;
+  }
+
+  protected function isJson(mixed $string)
+  {
+    if(\is_string($string))
+    {
+      json_decode($string);
+
+      return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    return false;
+  }
+
+  /**
    * Outputs the content as json string
    *
    * @param   mixed  $res  The output
@@ -155,12 +231,16 @@ class JoomGalleryJsonView extends JsonView
     $input = $this->app->getInput();
 
     // Serializing the output
-    $result = json_encode($res);
+    if($this->isJson($res))
+    {
+      // Content must not be serialized
+      $res = json_decode($res);
+    }
 
     // Pushing output to the document
-    $this->getDocument()->setBuffer($result);
+    $this->getDocument()->setBuffer($res);
 
     // Output json response
-    echo new JsonResponse($result, $this->message, $this->error, $input->get('ignoreMessages', true, 'bool'));
+    echo new JsonResponse($res, $this->message, $this->error, $input->get('ignoreMessages', true, 'bool'));
   }
 }

--- a/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
@@ -58,7 +58,7 @@ abstract class JoomGalleryRawView extends JoomGalleryView
     $this->app->setHeader('Status', (string) $status, true);
     $this->app->setHeader('Content-Type', 'text/plain; charset=utf-8', true);
     $this->app->setHeader('Cache-Control', 'no-store', true);
-    $this->app->setHeader('Content-Length', (string) strlen($message), true);
+    $this->app->setHeader('Content-Length', (string) \strlen($message), true);
 
     // Required for large files to work properly
     if(ob_get_level() > 0) ob_end_clean();

--- a/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
+++ b/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * *********************************************************************************
+ *    @package    com_joomgallery                                                 **
+ *    @author     JoomGallery::ProjectTeam <team@joomgalleryfriends.net>          **
+ *    @copyright  2008 - 2026  JoomGallery::ProjectTeam                           **
+ *    @license    GNU General Public License version 3 or later                   **
+ * *********************************************************************************
+ */
+
+namespace Joomgallery\Component\Joomgallery\Administrator\View;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') || die;
+// phpcs:enable PSR1.Files.SideEffects
+
+abstract class JoomGalleryRawView extends JoomGalleryView
+{
+  /**
+   * Send a binary resource to the client.
+   *
+   * @param   resource  $resource
+   * @param   string    $mimeType
+   * @param   string    $filename
+   * @param   int       $size
+   *
+   * @return  void
+   */
+  protected function outputResource($resource, string $mimeType, string $filename, int $size): void
+  {
+    // Set mime encoding to document
+    $this->getDocument()->setMimeEncoding($mimeType);
+
+    // Set header to specify the file name
+    $this->app->setHeader('Content-Type', $mimeType, true);
+    $this->app->setHeader('Content-Disposition', 'inline; filename="' . addcslashes(basename($filename), '"\\') . '"', true);
+    $this->app->setHeader('Content-Length', (string) $size, true);
+    $this->app->setHeader('Cache-Control', 'no-cache, must-revalidate', true);
+    $this->app->setHeader('Pragma', 'no-cache', true);
+
+    // Required for large files to work properly
+    if(ob_get_level() > 0) ob_end_clean();
+
+    fpassthru($resource);
+    fclose($resource);
+  }
+
+  /**
+   * Send an error response for a raw request.
+   *
+   * @param   int      $status
+   * @param   string   $message
+   *
+   * @return  void
+   */
+  protected function outputError(int $status, string $message): void
+  {
+    $this->app->setHeader('Status', (string) $status, true);
+    $this->app->setHeader('Content-Type', 'text/plain; charset=utf-8', true);
+    $this->app->setHeader('Cache-Control', 'no-store', true);
+    $this->app->setHeader('Content-Length', (string) strlen($message), true);
+
+    // Required for large files to work properly
+    if(ob_get_level() > 0) ob_end_clean();
+
+    echo $message;
+
+    $this->app->close();
+  }
+}

--- a/site/com_joomgallery/src/View/Category/JsonView.php
+++ b/site/com_joomgallery/src/View/Category/JsonView.php
@@ -14,8 +14,8 @@ namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 \defined('_JEXEC') || die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryJsonView;
 use Joomgallery\Component\Joomgallery\Site\Model\CategoryModel;
-use Joomgallery\Component\Joomgallery\Site\View\JoomGalleryJsonView;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -60,7 +60,7 @@ class JsonView extends JoomGalleryJsonView
     // Check published state
     if($loaded && $this->item->published !== 1)
     {
-      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
+      $this->output(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'));
 
       return;
     }
@@ -73,16 +73,29 @@ class JsonView extends JoomGalleryJsonView
       return;
     }
 
-    // Load parent category
-    $this->item->parent = $model->getParent();
+    // Load only if category is currently not protected
+    if(!$this->item->pw_protected)
+    {
+      // Load parent category
+      $this->item->parent = $model->getParent();
 
-    // Load subcategories
-    $this->item->children        = new \stdClass();
-    $this->item->children->items = $model->getChildren();
+      // Load subcategories
+      $this->item->children        = new \stdClass();
+      $this->item->children->items = $model->getChildren();
 
-    // Load images
-    $this->item->images        = new \stdClass();
-    $this->item->images->items = $model->getImages();
+      // Load images
+      $this->item->images        = new \stdClass();
+      $this->item->images->items = $model->getImages();
+    }
+    else
+    {
+      // Protected category
+      $this->error   = true;
+      $this->message = Text::_('COM_JOOMGALLERY_CATEGORY_PASSWORD_PROTECTED');
+      $this->output((object) []);
+
+      return;
+    }
 
     // Check for errors.
     if(\count($errors = $model->getErrors()))

--- a/site/com_joomgallery/src/View/Category/RawView.php
+++ b/site/com_joomgallery/src/View/Category/RawView.php
@@ -15,7 +15,7 @@ namespace Joomgallery\Component\Joomgallery\Site\View\Category;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomgallery\Component\Joomgallery\Administrator\View\Category\RawView as AdminRawView;
-use Joomla\Language\Text;
+use Joomla\CMS\Language\Text;
 
 /**
  * Raw view class for a single Category-Image.
@@ -34,12 +34,25 @@ class RawView extends AdminRawView
    */
   public function display($tpl = null)
   {
-    parent::display($tpl);
+    /** @var CategoryModel $model */
+    $model = $this->getModel();
+
+    $this->state = $model->getState();
+
+    $loaded = true;
+    try
+    {
+      $this->item = $model->getItem();
+    }
+    catch (\Exception $e)
+    {
+      $loaded = false;
+    }
 
     // Check published state
-    if($this->item->id && $this->item->published !== 1)
+    if($loaded && $this->item->published !== 1)
     {
-      $this->app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW'), 'error');
+      echo Text::_('COM_JOOMGALLERY_ERROR_UNAVAILABLE_VIEW');
 
       return;
     }
@@ -47,9 +60,19 @@ class RawView extends AdminRawView
     // Check access view level
     if(!\in_array($this->item->access, $this->user->getAuthorisedViewLevels()))
     {
-      $this->output(Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW'));
+      echo Text::_('COM_JOOMGALLERY_ERROR_ACCESS_VIEW');
 
       return;
+    }
+
+    // Load only if category is currently not protected
+    if(!$this->item->pw_protected)
+    {
+      parent::display($tpl);
+    }
+    else
+    {
+      echo Text::_('COM_JOOMGALLERY_CATEGORY_PASSWORD_PROTECTED');
     }
   }
 }


### PR DESCRIPTION
We were kindly informed by the security researcher **Toan Le** that we have a security-related bug in the JSON endpoints.
I took this as an opportunity to optimize the RAW and JSON endpoints in general while also fixing the reported bug.

<hr>

# How to test this PR

This PR fixes an information disclosure through JoomGallery's non-HTML endpoints and refactors the handling of JSON and RAW responses.

**Visit non html endpoints in the frontend:**
- `/index.php?option=com_joomgallery&view=category&id=3&format=json`
- `/index.php?option=com_joomgallery&view=category&id=3&format=raw`
- `/index.php?option=com_joomgallery&view=image&id=3&format=raw`

Exchange the `id` to existing category or image ids. Check out images and categories with different access permissions. Also check images and subcategories of password protected categories.
You should get a proper error response if you should not have access.

**The main purpose of this test is to verify that:**

- [ ] users can still access images/categories they are allowed to see
- [ ] access restrictions are also respected by the JSON and RAW endpoints
- [ ] password-protected categories do not expose their contents before being unlocked
- [ ] protected data cannot be obtained from a previously cached response
- [ ] RAW image responses are delivered correctly
- [ ] RAW error responses are returned as plain errors instead of redirects or HTML pages
- [ ] Images inside a protected category can not be viewed
- [ ] normal HTML category and image views still work