### PR TITLE
Add default tasks during installation

### DIFF
--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -332,6 +332,7 @@ COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_CATEGORY="Default category could not be cre
 COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_CONFIG="Default configuration set could not be created."
 COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_IMAGETYPE="Default imagetypes (Original, Detail, Thumbnail) could not be created."
 COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_MENU="Default menu items could not be created."
+COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_MENU="Error when creating JoomGallery default menu items."
 COM_JOOMGALLERY_SUCCESS_UPDATE="JoomGallery was updated to version %s successfully."
 COM_JOOMGALLERY_SUCCESS_UNINSTALL="JoomGallery was uninstalled successfully!"
 COM_JOOMGALLERY_SUCCESS_UNINSTALL_TXT="Please remember to remove your images folders manually if you didn't use JoomGallery's default directories."

--- a/administrator/com_joomgallery/language/en-GB/com_joomgallery.sys.ini
+++ b/administrator/com_joomgallery/language/en-GB/com_joomgallery.sys.ini
@@ -42,6 +42,7 @@ COM_JOOMGALLERY_SERVICE_ERROR_CREATE_CATEGORY="Error when creating JoomGallery d
 COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_CONFIG="Error when creating JoomGallery default configuration."
 COM_JOOMGALLERY_SERVICE_ERROR_DELETE_CATEGORY="Error when deleting category directories."
 COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_MENU="Error when creating JoomGallery default menu items."
+COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS="Error when creating JoomGallery default sheduled tasks."
 COM_JOOMGALLERY_ERROR_INSTALL_EXT="Error when installing %s with name %s"
 COM_JOOMGALLERY_ERROR_UNINSTALL_EXT="Error when uninstalling %s with name %s"
 COM_JOOMGALLERY_SERVICE_ERROR_COPY_IMAGETYPE="Error when copying file %s"

--- a/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -21,3 +21,4 @@ DELETE FROM `#__mail_templates` WHERE (extension LIKE 'com_joomgallery%');
 DELETE `#__fields_values` FROM `#__fields_values` INNER JOIN `#__fields` ON `#__fields`.`id` = `#__fields_values`.`field_id` WHERE (`#__fields`.`context` LIKE 'com_joomgallery%');
 DELETE FROM `#__fields_groups` WHERE (context LIKE 'com_joomgallery%');
 DELETE FROM `#__fields` WHERE (context LIKE 'com_joomgallery%');
+DELETE FROM `#__scheduler_tasks` WHERE (type LIKE 'joomgallery%');

--- a/administrator/com_joomgallery/src/Service/Search/Search.php
+++ b/administrator/com_joomgallery/src/Service/Search/Search.php
@@ -16,6 +16,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Search;
 
 use Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\SearchInterface;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Registry\Registry;
@@ -73,13 +74,13 @@ class Search implements SearchInterface
    * Constructor
    *
    * @param  DatabaseInterface  $db      The databse
-   * @param  Registry           $state   The state object
+   * @param  Registry|CMSObject $state   The state object
    *
    * @return  void
    *
    * @since   4.4.0
    */
-  public function __construct(DatabaseInterface $db, Registry $state)
+  public function __construct(DatabaseInterface $db, Registry|CMSObject $state)
   {
     $this->db    = $db;
     $this->state = $state;

--- a/administrator/com_joomgallery/src/Service/Search/SearchServiceTrait.php
+++ b/administrator/com_joomgallery/src/Service/Search/SearchServiceTrait.php
@@ -17,6 +17,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Search;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\FinderSearch;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\SQLSearch;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
@@ -68,14 +69,14 @@ trait SearchServiceTrait
   /**
    * Creates the search helper class
    *
-   * @param   string      $search  Name of the search to be used
-   * @param   Registry    $state   The state object
+   * @param   string               $search  Name of the search to be used
+   * @param   Registry|CMSObject   $state   The state object
    *
    * @return  void
    *
    * @since  4.4.0
    */
-  public function createSearch($search, DatabaseInterface $db, Registry $state): void
+  public function createSearch($search, DatabaseInterface $db, Registry|CMSObject $state): void
   {
     switch($search)
     {

--- a/administrator/com_joomgallery/src/Table/JoomTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/JoomTableTrait.php
@@ -45,19 +45,6 @@ trait JoomTableTrait
   protected $component_exists = true;
 
   /**
-   * Joomla 4 / 5 compatible database getter.
-   */
-  public function getDatabase(): DatabaseInterface
-  {
-    if(method_exists(get_parent_class($this), 'getDatabase'))
-    {
-      return parent::getDatabase();
-    }
-
-    return $this->getDbo();
-  }
-
-  /**
    * Delete a record by id
    *
    * @param   mixed  $pk  Primary key value to delete. Optional

--- a/administrator/com_joomgallery/src/Table/JoomTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/JoomTableTrait.php
@@ -44,6 +44,19 @@ trait JoomTableTrait
   protected $component_exists = true;
 
   /**
+   * Joomla 4 / 5 compatible database getter.
+   */
+  public function getDatabase(): DatabaseInterface
+  {
+    if(method_exists(get_parent_class($this), 'getDatabase'))
+    {
+      return parent::getDatabase();
+    }
+
+    return $this->getDbo();
+  }
+
+  /**
    * Delete a record by id
    *
    * @param   mixed  $pk  Primary key value to delete. Optional

--- a/administrator/com_joomgallery/src/Table/JoomTableTrait.php
+++ b/administrator/com_joomgallery/src/Table/JoomTableTrait.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Form\Form;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;

--- a/script.php
+++ b/script.php
@@ -399,6 +399,13 @@ class com_joomgalleryInstallerScript extends InstallerScript
       'height'     => 'fit-content',
     ];
 
+    // Create default scheduled tasks
+    if(!$this->addDefaultTasks())
+    {
+      $app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS', 'error'));
+      Log::add(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS'), 8, 'joomgallery');
+    }
+
     if(version_compare(JVERSION, '5.1.0', '>'))
     {
       /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
@@ -554,6 +561,13 @@ class com_joomgalleryInstallerScript extends InstallerScript
       {
         $app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_MENU', 'error'));
         Log::add(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_MENU'), 8, 'joomgallery');
+      }
+
+      // Create default scheduled tasks
+      if(!$this->addDefaultTasks())
+      {
+        $app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS', 'error'));
+        Log::add(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS'), 8, 'joomgallery');
       }
 
       // Create default mail templates
@@ -1022,6 +1036,96 @@ class com_joomgalleryInstallerScript extends InstallerScript
     // Insert the object into the user profile table.
     if(!$db->insertObject(_JOOM_TABLE_IMG_TYPES, $record))
     {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Add tasks to the ´#__scheduler_tasks´ table
+   *
+   * @return  bool  true on success
+   */
+  public function addDefaultTasks()
+  {
+    // Task types to be installed
+    $types = ['recreateImage'];
+
+    $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+    $query = $db->getQuery(true);
+    $query->select('type')->from('#__scheduler_tasks');
+    $query->where($db->quoteName('type') . ' LIKE ' . $db->quote('joomgalleryTask.%'));
+    $db->setQuery($query);
+
+    $installed_tasks = $db->loadColumn();
+
+    foreach($types as $typeName)
+    {
+      $taskType = 'joomgalleryTask.' . $typeName;
+
+      if(!in_array($taskType, $installedTasks, true))
+      {
+        if(!$this->addDefaultTask($typeName))
+        {
+          Factory::getApplication()->enqueueMessage('Failed installing task ' . $typeName, 'error');
+          Log::add('Failed installing task ' . $typeName, 8, 'joomgallery');
+
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Add a task to the ´#__scheduler_tasks´ table
+   *
+   * @param   string $type Task type name
+   *
+   * @return  bool   true on success
+   */
+  public function addDefaultTask(string $type): bool
+  {
+    switch($type)
+    {
+      case 'recreateImage':
+        // Default recreateImage task
+        $taskdata                    = [];
+        $taskdata['id']              = null;
+        $taskdata['title']           = 'Recreate Images';
+        $taskdata['type']            = 'joomgalleryTask.recreateImage';
+        $taskdata['state']           = 1;
+        $taskdata['execution_rules'] = '{"rule-type":"manual","exec-day":"7","exec-time":"00:00:00"}';
+        $taskdata['cron_rules']      = '{"type":"manual","exp":""}';
+        $taskdata['params']          = '{"individual_log":false,"log_file":"","notifications":{"success_mail":"0","failure_mail":"1","fatal_failure_mail":"1","orphan_mail":"1"},"cid":"0","type":"thumbnail","resume":"1","user":"","overrideable_params":"type","successful":""}';
+
+        break;
+
+      default:
+        return false;
+    }
+
+    try {
+      // Create the table
+      $scheduler = Factory::getApplication()->bootComponent('com_scheduler');
+      $model     = $scheduler->getMVCFactory()->createModel('Task', 'Administrator', ['ignore_request' => true]);
+
+      if(!$model->save($taskdata))
+      {
+        Factory::getApplication()->enqueueMessage('This default scheduled task could not be created: ' . $type, 'notice');
+        Log::add('This default scheduled task could not be created: ' . $type, 8, 'joomgallery');
+
+        return false;
+      }
+    }
+    catch (\Throwable $e)
+    {
+      Factory::getApplication()->enqueueMessage('This default scheduled task could not be created: ' . $type, 'notice');
+      Log::add('This default scheduled task could not be created: ' . $type, 8, 'joomgallery');
+
       return false;
     }
 

--- a/script.php
+++ b/script.php
@@ -1098,7 +1098,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
         $taskdata['title']           = 'Recreate Images';
         $taskdata['type']            = 'joomgalleryTask.recreateImage';
         $taskdata['state']           = 1;
-        $taskdata['execution_rules'] = '{"rule-type":"manual","exec-day":"7","exec-time":"00:00:00"}';
+        $taskdata['execution_rules'] = '{"rule-type":"manual","exec-day":"7","exec-time":"01:00:00"}';
         $taskdata['cron_rules']      = '{"type":"manual","exp":""}';
         $taskdata['params']          = '{"individual_log":false,"log_file":"","notifications":{"success_mail":"0","failure_mail":"1","fatal_failure_mail":"1","orphan_mail":"1"},"cid":"0","type":"thumbnail","resume":"1","user":"","overrideable_params":"type","successful":""}';
 
@@ -1112,6 +1112,20 @@ class com_joomgalleryInstallerScript extends InstallerScript
       // Create the table
       $scheduler = Factory::getApplication()->bootComponent('com_scheduler');
       $model     = $scheduler->getMVCFactory()->createModel('Task', 'Administrator', ['ignore_request' => true]);
+
+      // Turn json to array
+      if(is_string($taskdata['execution_rules']))
+      {
+        $taskdata['execution_rules'] = json_decode($taskdata['execution_rules'], true);
+      }
+      if(is_string($taskdata['cron_rules']))
+      {
+        $taskdata['cron_rules'] = json_decode($taskdata['cron_rules'], true);
+      }
+      if(is_string($taskdata['params']))
+      {
+        $taskdata['params'] = json_decode($taskdata['params'], true);
+      }
 
       if(!$model->save($taskdata))
       {

--- a/script.php
+++ b/script.php
@@ -402,7 +402,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     // Create default scheduled tasks
     if(!$this->addDefaultTasks())
     {
-      $app->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS', 'error'));
+      Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS', 'error'));
       Log::add(Text::_('COM_JOOMGALLERY_ERROR_CREATE_DEFAULT_TASKS'), 8, 'joomgallery');
     }
 

--- a/script.php
+++ b/script.php
@@ -1059,7 +1059,7 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $query->where($db->quoteName('type') . ' LIKE ' . $db->quote('joomgalleryTask.%'));
     $db->setQuery($query);
 
-    $installed_tasks = $db->loadColumn();
+    $installedTasks = $db->loadColumn();
 
     foreach($types as $typeName)
     {


### PR DESCRIPTION
This PR adds default tasks to the scheduled tasks during installation. This is needed to be able to perform `recreate Images` directly from the beginning.