### PR TITLE
[Chore] Remove database field 'jg_maxuploadfields'

### DIFF
--- a/script.php
+++ b/script.php
@@ -820,7 +820,6 @@ class com_joomgalleryInstallerScript extends InstallerScript
     $data['jg_maxuserimage']          = 500;
     $data['jg_maxuserimage_timespan'] = 0;
     $data['jg_maxfilesize']           = 2;
-    $data['jg_maxuploadfields']       = 3;
     $data['jg_maxvoting']             = 5;
 
     if(!$table->bind($data))

--- a/src/administrator/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/src/administrator/com_joomgallery/sql/install.mysql.utf8.sql
@@ -228,7 +228,6 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_configs` (
 `jg_newpiccopyright` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_uploaddefaultcat` TINYINT(1) NOT NULL DEFAULT 0,
 `jg_useruploadsingle` TINYINT(1) NOT NULL DEFAULT 1,
-`jg_maxuploadfields` DOUBLE NOT NULL DEFAULT 3,
 `jg_useruploadajax` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_useruploadbatch` TINYINT(1) NOT NULL DEFAULT 1,
 `jg_special_upload` TINYINT(1) NOT NULL DEFAULT 1,

--- a/src/administrator/com_joomgallery/sql/updates/mysql/4.5.0.sql
+++ b/src/administrator/com_joomgallery/sql/updates/mysql/4.5.0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__joomgallery_configs` DROP COLUMN `jg_maxuploadfields`;

--- a/src/administrator/com_joomgallery/src/Table/ConfigTable.php
+++ b/src/administrator/com_joomgallery/src/Table/ConfigTable.php
@@ -155,9 +155,6 @@ class ConfigTable extends Table
     // Support for number field: jg_maxfilesize
     $this->numberFieldSupport($array, 'jg_maxfilesize');
 
-    // Support for number field: jg_maxuploadfields
-    $this->numberFieldSupport($array, 'jg_maxuploadfields');
-
     // Support for number field: jg_maxvoting
     $this->numberFieldSupport($array, 'jg_maxvoting');
 


### PR DESCRIPTION
An unnecessary field, 'jg_maxuploadfields', is defined in the configuration table.
In JG3, this field defined the number of upload fields for HTML uploads. It is expected that this upload option will no longer be available in JG 4+.
Currently, every time the JoomGallery configuration is saved, a warning is written to the log:
`PHP Warning:  Undefined array key "jg_maxuploadfields" in ...administrator/components/com_joomgallery/src/Table/JoomTableTrait.php on line 453`
This PR removes the database field.

### How to test this PR
After applying this PR everything should work as usual.