### PR TITLE
[Chore] Fix warning PHP Deprecated:  Creation of dynamic property...

### DIFF
--- a/src/administrator/com_joomgallery/src/Service/IMGtools/GifFrameExtractor.php
+++ b/src/administrator/com_joomgallery/src/Service/IMGtools/GifFrameExtractor.php
@@ -99,6 +99,16 @@ class GifFrameExtractor
   /**
    * @var integer
    */
+  private $gifWidth;
+
+  /**
+   * @var integer
+   */
+  private $gifHeight;
+
+  /**
+   * @var integer
+   */
   private $totalDuration;
 
   /**

--- a/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
+++ b/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
@@ -106,7 +106,14 @@ final class JoomImage extends Adapter implements SubscriberInterface
    * @var    mixed
    * @since  4.4.0
    */
-  protected $tmp = null;
+  protected $tmp              = null;
+  protected $old_catpublished = null;
+  protected $old_cathidden    = null;
+  protected $old_catinhidden  = null;
+  protected $old_catexclude   = null;
+  protected $old_published    = null;
+  protected $old_approved     = null;
+  protected $old_hidden       = null;
 
   /**
    * Returns an array of events this subscriber will listen to.


### PR DESCRIPTION
This PR resolves the message '`PHP Deprecated:  Creation of dynamic property...`'
These messages are logged in the log file when certain actions are carried out. These warnings are not always visible on screen.
These actions are: editing categories, editing images, Uploading GIF files.

### After applying this PR
All should work as expected.