### PR TITLE
[Feature] multilingual image translations

### DIFF
--- a/src/administrator/com_joomgallery/forms/image.xml
+++ b/src/administrator/com_joomgallery/forms/image.xml
@@ -335,4 +335,5 @@
            size="45"
            labelclass="control-label" />
   </fieldset>
+  <fields name="translations" />  
 </form>

--- a/src/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
+++ b/src/administrator/com_joomgallery/language/en-GB/com_joomgallery.ini
@@ -1030,3 +1030,4 @@ COM_JOOMGALLERY_UPLOAD_MEDIA_LIMIT_IS="Joomla! media upload limit: "
 
 ; Plugin events
 COM_JOOMGALLERY_PLUGIN_ERROR_RETURN_VALUE="Return value of the plugin event '%s' must be of type %s and contain : %s"
+COM_JOOMGALLERY_IMAGE_TRANSLATIONS="Translations"

--- a/src/administrator/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/src/administrator/com_joomgallery/sql/install.mysql.utf8.sql
@@ -53,6 +53,25 @@ FULLTEXT INDEX `idx_text_language` (`title`, `description`)
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `#__joomgallery_image_translations`
+--
+
+CREATE TABLE IF NOT EXISTS `#__joomgallery_image_translations` (
+`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+`image_id` INT(11) UNSIGNED NOT NULL,
+`language` CHAR(7) NOT NULL,
+`title` VARCHAR(255) NOT NULL DEFAULT "",
+`alias` VARCHAR(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT "",
+`description` TEXT NOT NULL,
+PRIMARY KEY (`id`),
+UNIQUE KEY `idx_image_language` (`image_id`, `language`),
+KEY `idx_image_id` (`image_id`),
+KEY `idx_language` (`language`),
+KEY `idx_alias` (`alias`(191))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `#__joomgallery_categories`
 --
 

--- a/src/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/src/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS `#__joomgallery`;
+DROP TABLE IF EXISTS `#__joomgallery_image_translations`;
 DROP TABLE IF EXISTS `#__joomgallery_categories`;
 DROP TABLE IF EXISTS `#__joomgallery_collections`;
 DROP TABLE IF EXISTS `#__joomgallery_collections_ref`;

--- a/src/administrator/com_joomgallery/sql/updates/mysql/4.5.0.sql
+++ b/src/administrator/com_joomgallery/sql/updates/mysql/4.5.0.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `#__joomgallery_image_translations` (
+`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+`image_id` INT(11) UNSIGNED NOT NULL,
+`language` CHAR(7) NOT NULL,
+`title` VARCHAR(255) NOT NULL DEFAULT "",
+`alias` VARCHAR(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT "",
+`description` TEXT NOT NULL,
+PRIMARY KEY (`id`),
+UNIQUE KEY `idx_image_language` (`image_id`, `language`),
+KEY `idx_image_id` (`image_id`),
+KEY `idx_language` (`language`),
+KEY `idx_alias` (`alias`(191))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/src/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -18,6 +18,7 @@ use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -122,6 +123,35 @@ class ImageModel extends JoomAdminModel
     if(empty($form))
     {
       return false;
+    }
+
+    if(Multilanguage::isEnabled())
+    {
+      foreach(LanguageHelper::getContentLanguages() as $language)
+      {
+        $suffix = str_replace('-', '_', strtolower($language->lang_code));
+
+        $form->setField(
+            new \SimpleXMLElement(
+                '<field name="translation_' . $suffix . '_title" type="text" maxlength="255" filter="string" label="JGLOBAL_TITLE" />'
+            ),
+            'translations'
+        );
+
+        $form->setField(
+            new \SimpleXMLElement(
+                '<field name="translation_' . $suffix . '_alias" type="text" maxlength="255" filter="cmd" label="JALIAS" />'
+            ),
+            'translations'
+        );
+
+        $form->setField(
+            new \SimpleXMLElement(
+                '<field name="translation_' . $suffix . '_description" type="editor" rows="12" buttons="true" filter="\Joomla\CMS\Component\ComponentHelper::filterText" label="JGLOBAL_DESCRIPTION" />'
+            ),
+            'translations'
+        );
+      }
     }
 
     // On edit, we get ID from state, but on save, we use data from input
@@ -240,6 +270,75 @@ class ImageModel extends JoomAdminModel
     $this->item = $table->getFieldsValues();
 
     return $this->item;
+  }
+
+  public function getTranslations(int $imageId): array
+  {
+    if($imageId <= 0)
+    {
+      return [];
+    }
+
+    $db    = $this->getDatabase();
+    $query = $db->getQuery(true)
+    ->select(
+        [
+            $db->quoteName('language'),
+            $db->quoteName('title'),
+            $db->quoteName('alias'),
+            $db->quoteName('description'),
+          ]
+    )
+      ->from($db->quoteName('#__joomgallery_image_translations'))
+      ->where($db->quoteName('image_id') . ' = :imageId')
+      ->bind(':imageId', $imageId, ParameterType::INTEGER);
+
+    $db->setQuery($query);
+
+    return $db->loadObjectList('language');
+  }
+
+  protected function saveTranslations(int $imageId, array $translations): void
+  {
+    if($imageId <= 0)
+    {
+      return;
+    }
+
+    $db = $this->getDatabase();
+
+    foreach(LanguageHelper::getContentLanguages() as $language)
+    {
+      $suffix      = str_replace('-', '_', strtolower($language->lang_code));
+      $title       = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
+      $alias       = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
+      $description = (string) ($translations['translation_' . $suffix . '_description'] ?? '');
+
+      $query = $db->getQuery(true)
+        ->delete($db->quoteName('#__joomgallery_image_translations'))
+        ->where($db->quoteName('image_id') . ' = :imageId')
+        ->where($db->quoteName('language') . ' = :language')
+        ->bind(':imageId', $imageId, ParameterType::INTEGER)
+        ->bind(':language', $language->lang_code, ParameterType::STRING);
+
+      $db->setQuery($query);
+      $db->execute();
+
+      if($title === '' && $alias === '' && trim($description) === '')
+      {
+        continue;
+      }
+
+      $translation = (object) [
+        'image_id'    => $imageId,
+        'language'    => $language->lang_code,
+        'title'       => $title,
+        'alias'       => $alias,
+        'description' => $description,
+      ];
+
+      $db->insertObject('#__joomgallery_image_translations', $translation);
+    }
   }
 
   /**
@@ -670,6 +769,12 @@ class ImageModel extends JoomAdminModel
         }
       }
 
+      // Save image translations
+      if(Multilanguage::isEnabled() && isset($data['translations']))
+      {
+        $this->saveTranslations((int) $table->$key, (array) $data['translations']);
+      }
+
       // Handle ajax uploads
       if($isAjax)
       {
@@ -810,6 +915,17 @@ class ImageModel extends JoomAdminModel
 
             $db->setQuery($query);
             $db->execute();
+
+          // Delete corresponding image translations
+          $query = $db->getQuery(true)
+            ->delete($db->quoteName('#__joomgallery_image_translations'))
+            ->where(
+                $db->quoteName('image_id') . ' = :pk',
+            )
+            ->bind(':pk', $pk, ParameterType::INTEGER);
+
+          $db->setQuery($query);
+          $db->execute();
 
           // Multilanguage: if associated, delete the item in the _associations table
           if($this->associationsContext && Associations::isEnabled())

--- a/src/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -16,12 +16,12 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
@@ -310,13 +310,14 @@ class ImageModel extends JoomAdminModel
 
     foreach(LanguageHelper::getContentLanguages() as $language)
     {
-      $suffix      = str_replace('-', '_', strtolower($language->lang_code));
-      $title       = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
-      $alias       = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
+      $suffix = str_replace('-', '_', strtolower($language->lang_code));
+      $title = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
+      $alias = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
+
       if($alias === '' && $title !== '')
       {
         $alias = OutputFilter::stringURLSafe($title);
-      }      
+      }
       $description = (string) ($translations['translation_' . $suffix . '_description'] ?? '');
 
       $query = $db->getQuery(true)

--- a/src/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
@@ -312,6 +313,10 @@ class ImageModel extends JoomAdminModel
       $suffix      = str_replace('-', '_', strtolower($language->lang_code));
       $title       = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
       $alias       = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
+      if($alias === '' && $title !== '')
+      {
+        $alias = OutputFilter::stringURLSafe($title);
+      }      
       $description = (string) ($translations['translation_' . $suffix . '_description'] ?? '');
 
       $query = $db->getQuery(true)

--- a/src/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -311,8 +311,8 @@ class ImageModel extends JoomAdminModel
     foreach(LanguageHelper::getContentLanguages() as $language)
     {
       $suffix = str_replace('-', '_', strtolower($language->lang_code));
-      $title = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
-      $alias = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
+      $title  = trim((string) ($translations['translation_' . $suffix . '_title'] ?? ''));
+      $alias  = trim((string) ($translations['translation_' . $suffix . '_alias'] ?? ''));
 
       if($alias === '' && $title !== '')
       {

--- a/src/administrator/com_joomgallery/src/Model/ImageModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImageModel.php
@@ -283,11 +283,11 @@ class ImageModel extends JoomAdminModel
     $query = $db->getQuery(true)
     ->select(
         [
-            $db->quoteName('language'),
-            $db->quoteName('title'),
-            $db->quoteName('alias'),
-            $db->quoteName('description'),
-          ]
+          $db->quoteName('language'),
+          $db->quoteName('title'),
+          $db->quoteName('alias'),
+          $db->quoteName('description'),
+        ]
     )
       ->from($db->quoteName('#__joomgallery_image_translations'))
       ->where($db->quoteName('image_id') . ' = :imageId')

--- a/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -69,6 +69,14 @@ class HtmlView extends JoomGalleryView
     $this->contentLanguages = LanguageHelper::getContentLanguages();
     $this->translations     = $model->getTranslations((int) $this->item->id);
 
+    if(!empty($this->item->language) && $this->item->language !== '*')
+    {
+      $this->contentLanguages = array_filter(
+          $this->contentLanguages,
+          fn($language) => $language->lang_code !== $this->item->language
+      );
+    }
+
     foreach($this->contentLanguages as $language)
     {
       $suffix      = str_replace('-', '_', strtolower($language->lang_code));

--- a/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -71,10 +71,7 @@ class HtmlView extends JoomGalleryView
 
     if(!empty($this->item->language) && $this->item->language !== '*')
     {
-      $this->contentLanguages = array_filter(
-          $this->contentLanguages,
-          fn($language) => $language->lang_code !== $this->item->language
-      );
+      $this->contentLanguages = array_filter($this->contentLanguages, fn($language) => $language->lang_code !== $this->item->language);
     }
 
     foreach($this->contentLanguages as $language)

--- a/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
+++ b/src/administrator/com_joomgallery/src/View/Image/HtmlView.php
@@ -20,6 +20,7 @@ use Joomgallery\Component\Joomgallery\Administrator\View\JoomGalleryView;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\MediaHelper;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\Toolbar\Toolbar;
@@ -37,7 +38,8 @@ class HtmlView extends JoomGalleryView
   protected $form;
   protected $config;
   protected $imagetypes;
-
+  protected $contentLanguages;
+  protected $translations;
   protected $uploadLimit;
   protected $postMaxSize;
   protected $memoryLimit;
@@ -59,12 +61,25 @@ class HtmlView extends JoomGalleryView
     /** @var ImageModel $model */
     $model = $this->getModel();
 
-    $this->state      = $model->getState();
-    $this->item       = $model->getItem();
-    $this->form       = $model->getForm();
-    $this->config     = JoomHelper::getService('config');
-    $this->imagetypes = JoomHelper::getRecords('imagetypes');
-    $rating           = JoomHelper::getRating($this->item->id);
+    $this->state            = $model->getState();
+    $this->item             = $model->getItem();
+    $this->form             = $model->getForm();
+    $this->config           = JoomHelper::getService('config');
+    $this->imagetypes       = JoomHelper::getRecords('imagetypes');
+    $this->contentLanguages = LanguageHelper::getContentLanguages();
+    $this->translations     = $model->getTranslations((int) $this->item->id);
+
+    foreach($this->contentLanguages as $language)
+    {
+      $suffix      = str_replace('-', '_', strtolower($language->lang_code));
+      $translation = $this->translations[$language->lang_code] ?? null;
+
+      $this->form->setValue('translation_' . $suffix . '_title', 'translations', $translation->title ?? '');
+      $this->form->setValue('translation_' . $suffix . '_alias', 'translations', $translation->alias ?? '');
+      $this->form->setValue('translation_' . $suffix . '_description', 'translations', $translation->description ?? '');
+    }
+
+    $rating = JoomHelper::getRating($this->item->id);
     $this->form->setvalue('rating', '', $rating);
     $this->app->getLanguage()->load('com_joomgallery.exif', _JOOM_PATH_ADMIN);
     $this->app->getLanguage()->load('com_joomgallery.iptc', _JOOM_PATH_ADMIN);

--- a/src/administrator/com_joomgallery/tmpl/image/edit.php
+++ b/src/administrator/com_joomgallery/tmpl/image/edit.php
@@ -58,7 +58,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
   <div class="main-card">
   <?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'Details', 'recall' => true, 'breakpoint' => 768]); ?>
 
-  <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'Details', Text::_('JDETAILS', true)); ?>  
+  <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'Details', Text::_('JDETAILS', true)); ?>
   <div class="row">
     <div class="col-lg-9">
       <fieldset class="adminform">
@@ -80,6 +80,24 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
     </div>
   </div>
   <?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+  <?php if(!empty($this->contentLanguages)) : ?>
+    <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'Translations', Text::_('COM_JOOMGALLERY_IMAGE_TRANSLATIONS', true)); ?>
+
+    <?php foreach($this->contentLanguages as $language) : ?>
+      <?php $suffix = str_replace('-', '_', strtolower($language->lang_code)); ?>
+
+      <fieldset class="options-form">
+        <legend><?php echo htmlspecialchars($language->title_native, ENT_QUOTES, 'UTF-8'); ?></legend>
+
+        <?php echo $this->form->renderField('translation_' . $suffix . '_title', 'translations'); ?>
+        <?php echo $this->form->renderField('translation_' . $suffix . '_alias', 'translations'); ?>
+        <?php echo $this->form->renderField('translation_' . $suffix . '_description', 'translations'); ?>
+      </fieldset>
+    <?php endforeach; ?>
+
+    <?php echo HTMLHelper::_('uitab.endTab'); ?>
+  <?php endif; ?>
 
   <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'Images', Text::_('COM_JOOMGALLERY_IMAGES', true)); ?>
   <div class="row">
@@ -110,7 +128,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
           <?php echo $this->form->renderField('downloads'); ?>
           <?php echo $this->form->renderField('votes'); ?>
           <?php echo $this->form->renderField('rating'); ?>
-        </div>          
+        </div>
       </fieldset>
     </div>
   </div>
@@ -136,7 +154,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
           <?php echo $this->form->renderField('modified_time'); ?>
           <?php echo $this->form->renderField('modified_by'); ?>
           <?php echo $this->form->renderField('id'); ?>
-        </div>        
+        </div>
       </fieldset>
     </div>
     <div class="col-12 col-lg-6">
@@ -170,7 +188,7 @@ $tmpl    = $isModal || $app->input->get('tmpl', '', 'cmd') === 'component' ? '&t
         </fieldset>
       </div>
     <?php endif; ?>
-  </div>  
+  </div>
   <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
   <?php if($this->item->id) : ?>

--- a/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
+++ b/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
@@ -696,7 +696,7 @@ final class JoomImage extends Adapter implements SubscriberInterface
         ->select('t.language AS translation_language')
         ->from($this->table . ' AS i')
         ->join('INNER', '#__joomgallery_image_translations AS t ON t.image_id = i.id')
-        ->join('INNER', '#__joomgallery_image_translations AS t ON t.image_id = i.id')
+        ->join('INNER', '#__languages AS l ON l.lang_code = t.language AND l.published = 1')
         ->where('(i.language = ' . $db->quote('*') . ' OR t.language <> i.language)');
 
       // For an "All" image use the original values as fallback in every

--- a/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
+++ b/src/plugins/finder/joomgallery/src/Extension/JoomImage.php
@@ -17,14 +17,18 @@ namespace Joomgallery\Plugin\Finder\Joomgallery\Extension;
 use Joomgallery\Component\Joomgallery\Administrator\Helper\JoomHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Finder as FinderEvent;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\Component\Finder\Administrator\Indexer\Adapter;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
+use Joomla\Component\Finder\Administrator\Indexer\Taxonomy;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Smart Search adapter for JoomGallery Images.
@@ -537,7 +541,13 @@ final class JoomImage extends Adapter implements SubscriberInterface
     $item->summary = Helper::prepareContent($item->summary, $item->params, $item);
 
     // Build the necessary route and path information.
-    $item->url   = $this->getUrl($item->id, $this->extension, $this->layout);
+    $item->url = $this->getUrl($item->id, $this->extension, $this->layout);
+
+    if(!empty($item->translation_language))
+    {
+      $item->url .= '&lang=' . $item->translation_language;
+    }
+
     $item->route = JoomHelper::getViewRoute('image', $item->id, $item->catid, null, null, $item->language);
 
     // Get the menu title if it exists.
@@ -643,19 +653,244 @@ final class JoomImage extends Adapter implements SubscriberInterface
   {
     $db = $this->getDatabase();
 
-    // Check if we can use the supplied SQL query.
-    $query = $query instanceof QueryInterface ? $query : $db->getQuery(true)
-      ->select('a.id, a.title AS title, a.alias, a.author AS author, a.description AS summary')
-      ->select('a.published AS state, a.catid, a.date')
-      ->select('a.hidden, a.featured, a.checked_out, a.approved, a.params, a.language')
-      ->select('a.metakey, a.metadesc, a.access, a.ordering, a.created_time')
+    if($query instanceof QueryInterface)
+    {
+      return $query;
+    }
+
+    // Original image records.
+    $baseQuery = $db->createQuery()
+      ->select('i.id, i.title, i.alias, i.author, i.description AS summary')
+      ->select('i.published AS state, i.catid, i.date')
+      ->select('i.hidden, i.featured, i.checked_out, i.approved, i.params, i.language')
+      ->select('i.metakey, i.metadesc, i.access, i.ordering, i.created_time, i.created_by')
+      ->select($db->quote('') . ' AS translation_language')
+      ->from($this->table . ' AS i');
+
+    if(Multilanguage::isEnabled())
+    {
+      // Images assigned to "All" with translations must not also be
+      // indexed as wildcard entries.
+      $translationExists = $db->createQuery()
+        ->select('1')
+        ->from('#__joomgallery_image_translations AS tx')
+        ->join('INNER', '#__languages AS lx ON lx.lang_code = tx.language AND lx.published = 1')
+        ->where('tx.image_id = i.id');
+
+    $baseQuery->where(
+        '(i.language <> ' . $db->quote('*')
+          . ' OR NOT EXISTS (' . $translationExists . '))'
+    );
+
+      // Explicit translations.
+      $translationQuery = $db->createQuery()
+        ->select('i.id')
+        ->select('COALESCE(NULLIF(t.title, ' . $db->quote('') . '), i.title) AS title')
+        ->select('COALESCE(NULLIF(t.alias, ' . $db->quote('') . '), i.alias) AS alias')
+        ->select('i.author')
+        ->select('COALESCE(NULLIF(t.description, ' . $db->quote('') . '), i.description) AS summary')
+        ->select('i.published AS state, i.catid, i.date')
+        ->select('i.hidden, i.featured, i.checked_out, i.approved, i.params')
+        ->select('t.language AS language')
+        ->select('i.metakey, i.metadesc, i.access, i.ordering, i.created_time, i.created_by')
+        ->select('t.language AS translation_language')
+        ->from($this->table . ' AS i')
+        ->join('INNER', '#__joomgallery_image_translations AS t ON t.image_id = i.id')
+        ->join('INNER', '#__joomgallery_image_translations AS t ON t.image_id = i.id')
+        ->where('(i.language = ' . $db->quote('*') . ' OR t.language <> i.language)');
+
+      // For an "All" image use the original values as fallback in every
+      // published content language without an explicit translation.
+      $fallbackQuery = $db->createQuery()
+        ->select('i.id, i.title, i.alias, i.author, i.description AS summary')
+        ->select('i.published AS state, i.catid, i.date')
+        ->select('i.hidden, i.featured, i.checked_out, i.approved, i.params')
+        ->select('l.lang_code AS language')
+        ->select('i.metakey, i.metadesc, i.access, i.ordering, i.created_time, i.created_by')
+        ->select('l.lang_code AS translation_language')
+        ->from($this->table . ' AS i')
+        ->join('INNER', '#__languages AS l ON l.published = 1')
+        ->join(
+            'LEFT',
+            '#__joomgallery_image_translations AS t'
+            . ' ON t.image_id = i.id AND t.language = l.lang_code'
+        )
+        ->where('i.language = ' . $db->quote('*'))
+        ->where('t.id IS NULL')
+        ->where('EXISTS (' . $translationExists . ')');
+
+      $baseQuery = $baseQuery->toQuerySet()
+        ->unionAll($translationQuery)
+        ->unionAll($fallbackQuery);
+    }
+
+    $query = $db->createQuery()
+      ->select('a.*')
       ->select('c.title AS category, c.published AS cat_state')
       ->select('u.name AS owner')
-      ->from($this->table . ' AS a')
+      ->from('(' . $baseQuery . ') AS a')
       ->join('LEFT', '#__joomgallery_categories AS c ON c.id = a.catid')
-      ->join('LEFT', '#__users AS u ON u.id = a.created_by');
+      ->join('LEFT', '#__users AS u ON u.id = a.created_by')
+      ->order('a.id, a.translation_language');
 
     return $query;
+  }
+
+  /**
+   * Reindex all language variants of an image.
+   *
+   * @param   integer  $id  Image ID.
+   *
+   * @return  void
+   */
+  protected function reindex($id)
+  {
+    $this->setup();
+
+    // Remove all existing language variants first.
+    $this->remove($id, false);
+
+    $query = $this->getListQuery();
+    $query->where('a.id = ' . (int) $id);
+
+    $db = $this->getDatabase();
+    $db->setQuery($query);
+    $items = $db->loadAssocList();
+
+    foreach($items as $item)
+    {
+      $item = ArrayHelper::toObject($item, Result::class);
+
+      $item->type_id = $this->type_id;
+      $item->mime    = $this->mime;
+      $item->layout  = $this->layout;
+
+      $this->index($item);
+    }
+
+    Taxonomy::removeOrphanNodes();
+  }
+
+  /**
+   * Remove all language variants of an image from the index.
+   *
+   * @param   integer  $id                Image ID.
+   * @param   bool     $removeTaxonomies  Remove empty taxonomies.
+   *
+   * @return  boolean
+   */
+  protected function remove($id, $removeTaxonomies = true)
+  {
+    $db      = $this->getDatabase();
+    $baseUrl = $this->getUrl($id, $this->extension, $this->layout);
+
+    $query = $db->createQuery()
+      ->select($db->quoteName('link_id'))
+      ->from($db->quoteName('#__finder_links'))
+      ->where($db->quoteName('type_id') . ' = ' . (int) $this->type_id)
+    ->where(
+        '(' . $db->quoteName('url') . ' = ' . $db->quote($baseUrl)
+          . ' OR ' . $db->quoteName('url') . ' LIKE ' . $db->quote($baseUrl . '&lang=%') . ')'
+    );
+
+    $db->setQuery($query);
+    $items = $db->loadColumn();
+
+    if(empty($items))
+    {
+      Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', [$id]);
+
+      return true;
+    }
+
+    foreach($items as $item)
+    {
+      $this->indexer->remove($item, false);
+    }
+
+    if($removeTaxonomies)
+    {
+      Taxonomy::removeOrphanNodes();
+    }
+
+    return true;
+  }
+
+  /**
+   * Remove outdated index entries.
+   *
+   * @return  integer
+   */
+  public function onFinderGarbageCollection()
+  {
+    $db      = $this->getDatabase();
+    $typeId  = $this->getTypeId();
+    $baseUrl = $this->getUrl('', $this->extension, $this->layout);
+
+    // Build all currently valid URLs, including language variants.
+    $subquery = $db->createQuery()
+    ->select(
+        'CONCAT('
+          . $db->quote($baseUrl)
+          . ', a.id, CASE WHEN a.translation_language <> ' . $db->quote('')
+          . ' THEN CONCAT(' . $db->quote('&lang=') . ', a.translation_language)'
+          . ' ELSE ' . $db->quote('') . ' END)'
+    )
+      ->from('(' . $this->getListQuery() . ') AS a');
+
+    $query = $db->createQuery()
+      ->select($db->quoteName('l.link_id'))
+      ->from($db->quoteName('#__finder_links', 'l'))
+      ->where($db->quoteName('l.type_id') . ' = ' . (int) $typeId)
+    ->where(
+        $db->quoteName('l.url')
+          . ' LIKE '
+          . $db->quote($this->getUrl('%', $this->extension, $this->layout))
+    )
+      ->where($db->quoteName('l.url') . ' NOT IN (' . $subquery . ')');
+
+    $db->setQuery($query);
+    $items = $db->loadColumn();
+
+    foreach($items as $item)
+    {
+      $this->indexer->remove($item);
+    }
+
+    return \count($items);
+  }
+
+  /**
+   * Change a property for all language variants of an image.
+   *
+   * @param   string   $id        Image ID.
+   * @param   string   $property  Property to change.
+   * @param   integer  $value     New value.
+   *
+   * @return  boolean
+   */
+  protected function change($id, $property, $value)
+  {
+    if($property !== 'state' && $property !== 'access')
+    {
+      return true;
+    }
+
+    $db      = $this->getDatabase();
+    $baseUrl = $this->getUrl($id, $this->extension, $this->layout);
+
+    $query = $db->createQuery()
+      ->update($db->quoteName('#__finder_links'))
+      ->set($db->quoteName($property) . ' = ' . (int) $value)
+    ->where(
+        '(' . $db->quoteName('url') . ' = ' . $db->quote($baseUrl)
+          . ' OR ' . $db->quoteName('url') . ' LIKE ' . $db->quote($baseUrl . '&lang=%') . ')'
+    );
+
+    $db->setQuery($query);
+    $db->execute();
+
+    return true;
   }
 
   /**

--- a/src/site/com_joomgallery/src/Model/ImageModel.php
+++ b/src/site/com_joomgallery/src/Model/ImageModel.php
@@ -117,6 +117,20 @@ class ImageModel extends JoomAdminModel
       {
         throw new \Exception(Text::_('COM_JOOMGALLERY_ITEM_NOT_LOADED'), 404);
       }
+
+      if(Multilanguage::isEnabled())
+      {
+        $language     = Factory::getApplication()->getLanguage()->getTag();
+        $translations = $adminModel->getTranslations((int) $this->item->id);
+        $translation  = $translations[$language] ?? null;
+
+        if($translation)
+        {
+          $this->item->title       = $translation->title ?: $this->item->title;
+          $this->item->alias       = $translation->alias ?: $this->item->alias;
+          $this->item->description = $translation->description ?: $this->item->description;
+        }
+      }
     }
 
     if(isset($this->item->catid) && $this->item->catid != '')

--- a/src/site/com_joomgallery/src/Model/ImagesModel.php
+++ b/src/site/com_joomgallery/src/Model/ImagesModel.php
@@ -15,6 +15,9 @@ namespace Joomgallery\Component\Joomgallery\Site\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomgallery\Component\Joomgallery\Administrator\Model\ImagesModel as AdminImagesModel;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Multilanguage;
+use Joomla\Database\ParameterType;
 
 /**
  * Model to get a list of image records.
@@ -127,6 +130,45 @@ class ImagesModel extends AdminImagesModel
       {
         // Make sure $start=1 starts at the first image
         $items = \array_slice($items, $start - 1);
+      }
+    }
+
+    if(Multilanguage::isEnabled() && !empty($items))
+    {
+      $language = Factory::getApplication()->getLanguage()->getTag();
+    $imageIds   = array_map(
+        static fn($item) => (int) $item->id,
+        $items
+    );
+
+      $db    = $this->getDatabase();
+      $query = $db->getQuery(true)
+        ->select(
+            [
+              $db->quoteName('image_id'),
+              $db->quoteName('title'),
+              $db->quoteName('alias'),
+              $db->quoteName('description'),
+            ]
+        )
+        ->from($db->quoteName('#__joomgallery_image_translations'))
+        ->where($db->quoteName('language') . ' = :language')
+        ->whereIn($db->quoteName('image_id'), $imageIds, ParameterType::INTEGER)
+        ->bind(':language', $language, ParameterType::STRING);
+
+      $db->setQuery($query);
+      $translations = $db->loadObjectList('image_id');
+
+      foreach($items as $item)
+      {
+        $translation = $translations[(int) $item->id] ?? null;
+
+        if($translation)
+        {
+          $item->title       = $translation->title ?: $item->title;
+          $item->alias       = $translation->alias ?: $item->alias;
+          $item->description = $translation->description ?: $item->description;
+        }
       }
     }
 

--- a/src/site/com_joomgallery/src/Service/DefaultRouter.php
+++ b/src/site/com_joomgallery/src/Service/DefaultRouter.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Component\Router\Rules\MenuRules;
 use Joomla\CMS\Component\Router\Rules\NomenuRules;
 use Joomla\CMS\Component\Router\Rules\StandardRules;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
@@ -709,21 +710,38 @@ class DefaultRouter extends RouterView
    *
    * @since   4.2.0
    */
+
   public function getImageAliasDb(string $id): string
   {
-    $alias   = '';
-    $dbquery = $this->db->createQuery();
+    if(Multilanguage::isEnabled())
+    {
+      $language = Factory::getApplication()->getLanguage()->getTag();
+      $dbquery  = $this->db->createQuery()
+        ->select($this->db->quoteName('alias'))
+        ->from($this->db->quoteName('#__joomgallery_image_translations'))
+        ->where($this->db->quoteName('image_id') . ' = :id')
+        ->where($this->db->quoteName('language') . ' = :language')
+        ->bind(':id', $id, ParameterType::INTEGER)
+        ->bind(':language', $language, ParameterType::STRING);
 
-    $dbquery->select($this->db->quoteName('alias'))
+      $this->db->setQuery($dbquery);
+      $alias = (string) $this->db->loadResult();
+
+      if($alias !== '')
+      {
+        return $alias;
+      }
+    }
+
+    $dbquery = $this->db->createQuery()
+      ->select($this->db->quoteName('alias'))
       ->from($this->db->quoteName(_JOOM_TABLE_IMAGES))
       ->where($this->db->quoteName('id') . ' = :id')
       ->bind(':id', $id, ParameterType::INTEGER);
+
     $this->db->setQuery($dbquery);
 
-    // To create a segment in the form: id-alias
-    $alias = (string) $this->db->loadResult();
-
-    return $alias;
+    return (string) $this->db->loadResult();
   }
 
   /**

--- a/src/site/com_joomgallery/src/Service/JG3ModernRouter.php
+++ b/src/site/com_joomgallery/src/Service/JG3ModernRouter.php
@@ -215,16 +215,8 @@ class JG3ModernRouter extends DefaultRouter
         }
       }
 
-      $dbquery = $this->db->createQuery();
-
-      $dbquery->select($this->db->quoteName('alias'))
-        ->from($this->db->quoteName(_JOOM_TABLE_IMAGES))
-        ->where($this->db->quoteName('id') . ' = :id')
-        ->bind(':id', $id, ParameterType::INTEGER);
-      $this->db->setQuery($dbquery);
-
       // To create a segment in the form: alias-id
-      $id = $this->db->loadResult() . ':' . $id;
+      $id = $this->getImageAliasDb($id) . ':' . $id;
     }
 
     return [(int) $id => $id];
@@ -244,16 +236,8 @@ class JG3ModernRouter extends DefaultRouter
   {
     if(!strpos($id, ':'))
     {
-      $dbquery = $this->db->createQuery();
-
-      $dbquery->select($this->db->quoteName('alias'))
-        ->from($this->db->quoteName(_JOOM_TABLE_IMAGES))
-        ->where($this->db->quoteName('id') . ' = :id')
-        ->bind(':id', $id, ParameterType::INTEGER);
-      $this->db->setQuery($dbquery);
-
       // To create a segment in the form: alias-id
-      $id = $this->db->loadResult() . ':' . $id;
+      $id = $this->getImageAliasDb($id) . ':' . $id;
     }
 
     return [(int) $id => $id];

--- a/src/site/com_joomgallery/src/View/Image/HtmlView.php
+++ b/src/site/com_joomgallery/src/View/Image/HtmlView.php
@@ -178,7 +178,7 @@ class HtmlView extends JoomGalleryView
       $pathway        = $this->app->getPathway();
       $breadcrumbList = Text::_('COM_JOOMGALLERY_IMAGES');
 
-      if(!\in_array($breadcrumbList, $pathway->getPathwayNames()))
+      if(($menu->query['option'] ?? '') !== 'com_joomgallery' && !\in_array($breadcrumbList, $pathway->getPathwayNames()))
       {
         $pathway->addItem($breadcrumbList, JoomHelper::getViewRoute('images'));
       }


### PR DESCRIPTION
Adds multilingual translations for image title, alias and description.

- Keeps a single physical image record/file
- Stores translations in a separate translation table 
- Uses language-specific aliases in frontend URLs (Generates translated aliases automatically from translated titles)
- Falls back to the original image fields

How to test:
test on a site with more than one lanuage. Set a different title and description for every language under – Images :: Edit Image / Translations

Result:
The image title and details are in the selected language and the image detail page has the alias in the url

