### PR TITLE
[Bugfix] Images in modals not shown

### DIFF
--- a/src/administrator/com_joomgallery/tmpl/image/edit.php
+++ b/src/administrator/com_joomgallery/tmpl/image/edit.php
@@ -235,7 +235,7 @@ echo HTMLHelper::_('bootstrap.renderModal', 'image-modal-box', $options, '<div i
 
       foreach($this->imagetypes as $key => $imagetype)
       {
-        $imgURL[$imagetype->typename] = JoomHelper::getImg($this->item, $imagetype->typename);
+        $imgURL[$imagetype->typename] = htmlspecialchars_decode(JoomHelper::getImg($this->item, $imagetype->typename), ENT_QUOTES | ENT_HTML5);
         $title[$imagetype->typename]  = Text::_('COM_JOOMGALLERY_' . strtoupper($imagetype->typename));
 
         $img_path = str_replace('\\', '/', JoomHelper::getImg($this->item, $imagetype->typename, false, false));

--- a/src/site/com_joomgallery/tmpl/userimage/editimg.php
+++ b/src/site/com_joomgallery/tmpl/userimage/editimg.php
@@ -312,7 +312,7 @@ echo HTMLHelper::_('bootstrap.renderModal', 'image-modal-box', $options, '<div i
 
     foreach($this->imagetypes as $key => $imagetype)
     {
-      $imgURL[$imagetype->typename] = JoomHelper::getImg($this->item, $imagetype->typename);
+      $imgURL[$imagetype->typename] = htmlspecialchars_decode(JoomHelper::getImg($this->item, $imagetype->typename), ENT_QUOTES | ENT_HTML5);
       $title[$imagetype->typename]  = Text::_('COM_JOOMGALLERY_' . strtoupper($imagetype->typename));
 
       $img_path = str_replace('\\', '/', JoomHelper::getImg($this->item, $imagetype->typename, false, false));


### PR DESCRIPTION
This PR fixes issue #405.

With introducing stronger escaping in views template and layout files with PR #393, the URLs to imges in modals were escaped two times and thus ended in invalid URLs.

### How to test this PR
Go to backend and fronted image editing and open the image in the provided modals.