### PR TITLE
[Bugfix] Images shown as binary data

### DIFF
--- a/src/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
+++ b/src/administrator/com_joomgallery/src/View/JoomGalleryRawView.php
@@ -41,8 +41,12 @@ abstract class JoomGalleryRawView extends JoomGalleryView
     // Required for large files to work properly
     if(ob_get_level() > 0) ob_end_clean();
 
+    $this->app->sendHeaders();
+
     fpassthru($resource);
     fclose($resource);
+
+    $this->app->close();
   }
 
   /**


### PR DESCRIPTION
This PR tries to solve issue #202.

It tries to solve the issue by sending the http headers before the actual image data. This should prevent images request being sent without the proper http header data qualifying it as an image.