### PR TITLE
[Bugfix] Save category fails

### DIFF
--- a/src/administrator/com_joomgallery/src/Model/CategoryModel.php
+++ b/src/administrator/com_joomgallery/src/Model/CategoryModel.php
@@ -480,8 +480,19 @@ class CategoryModel extends JoomAdminModel
 
           // Check if filesystem adapter has changed
           $old_params = json_decode($table->params);
+          $old_adapter = $old_params->{'jg_filesystem'} ?? '';
 
-          if($old_params->{'jg_filesystem'} != $data['params']['jg_filesystem'])
+          // Disabled form fields are not submitted. Keep the stored adapter in that case.
+          if(!isset($data['params']) || !\is_array($data['params']))
+          {
+            $data['params'] = (array) $old_params;
+          }
+
+          if(!\array_key_exists('jg_filesystem', $data['params']))
+          {
+            $data['params']['jg_filesystem'] = $old_adapter;
+          }
+          elseif($old_adapter != $data['params']['jg_filesystem'])
           {
             $adapterChanged = true;
           }


### PR DESCRIPTION
This PR solves the issue of not being able to edit a category.

<img width="1634" height="340" alt="grafik" src="https://github.com/user-attachments/assets/9c69a824-47ff-415e-be02-e0734084e90f" />

The field `jg_filesystem` gets disabled when editing an existing category as moving a category from one filesystem to another is not yet supported. But a disabled field value is not send to the backend and then checked in the model.

### How to test this PR

1. Install JoomGallery and apply this PR
2. Add some categories (top level and subcategories)
3. Try to edit some values of the categories.

Before this PR you will get the error message shown above. 

After this PR category can be edited and saved successfully.