### PR TITLE
[Imporvement] Search adjustable UI fields

### DIFF
--- a/src/administrator/com_joomgallery/src/Model/ImagesModel.php
+++ b/src/administrator/com_joomgallery/src/Model/ImagesModel.php
@@ -15,8 +15,8 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Model;
 // phpcs:enable PSR1.Files.SideEffects
 
 use Joomgallery\Component\Joomgallery\Administrator\Model\JoomListModel;
+use Joomgallery\Component\Joomgallery\Administrator\Service\Search\SearchInterface;
 use Joomla\CMS\Factory;
-use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -37,12 +37,12 @@ class ImagesModel extends JoomListModel
   protected $type = 'image';
 
   /**
-   * Configuration param for search provider
+   * Service name or configuration param for search provider
    *
    * @access  public
    * @var     string
    */
-  public $search = 'jg_backend_searchprovider';
+  protected $search = 'jg_backend_searchprovider';
 
   /**
    * Constructor
@@ -198,6 +198,51 @@ class ImagesModel extends JoomListModel
   }
 
   /**
+   * Get the filter form adapted to the selected search provider.
+   *
+   * @param   array    $data      Data used to bind the form
+   * @param   boolean  $loadData  True to load the model state into the form
+   *
+   * @return  \Joomla\CMS\Form\Form|null
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function getFilterForm($data = [], $loadData = true)
+  {
+    $form = parent::getFilterForm($data, $loadData);
+
+    if($form === null)
+    {
+      return null;
+    }
+
+    $displayFields = $this->getSearchProvider()->getDisplayFields();
+
+    foreach(['filter', 'list'] as $group)
+    {
+      $visibleFields = $displayFields[$group] ?? null;
+
+      // A null allowlist means that the provider does not restrict this group.
+      if($visibleFields === null)
+      {
+        continue;
+      }
+
+      foreach($form->getGroup($group) as $field)
+      {
+        $fieldName = (string) $field->fieldname;
+
+        if(!\in_array($fieldName, $visibleFields, true))
+        {
+          $form->removeField($fieldName, $group);
+        }
+      }
+    }
+
+    return $form;
+  }
+
+  /**
    * Build an SQL query to load the list data.
    *
    * ToDo: Manuel
@@ -212,17 +257,7 @@ class ImagesModel extends JoomListModel
     $query = $db->getQuery(true);
 
     // Initialize search service
-    $this->component->createConfig();
-    try
-    {
-      $searchProvider = $this->component->getSearch();
-    }
-    catch (\TypeError $e)
-    {
-      $searchProviderName = $this->component->getConfig()->get($this->search, 'sql');
-      $this->component->createSearch($searchProviderName, $db, $this->state);
-      $searchProvider = $this->component->getSearch();
-    }
+    $searchProvider = $this->getSearchProvider();
 
     // Check if logic and is active
     $logicAnd = (bool) ($this->getState('filter.and') > 0);
@@ -345,15 +380,8 @@ class ImagesModel extends JoomListModel
     // Filter by search
     $search = trim((string) $this->getState('filter.search'));
 
-    $hasActiveSearchProviderFilter =
-      !empty($this->getState('filter.category'))
-      || !empty($this->getState('filter.tag'))
-      || !empty($this->getState('filter.language'));
-
-    if(!empty($search) || $hasActiveSearchProviderFilter)
-    {
-      $this->component->getSearch()->applyToQuery($query, $search, 'a');
-    }
+    // Let the provider decide whether the current search/filter state is active.
+    $searchProvider->applyToQuery($query, $search, 'a');
 
     // Filter by published state
     $published = (string) $this->getState('filter.published');
@@ -556,8 +584,8 @@ class ImagesModel extends JoomListModel
         ->bind(':endDate', $endDate);
     }
 
-    // Add the list ordering clause.
-    if(!$searchProvider->handlesOrdering())
+    // Give provider-specific result ordering precedence over list ordering.
+    if(!$searchProvider->applyOrderingToQuery($query))
     {
       $orderCol  = $this->getState('list.ordering', 'a.id');
       $orderDirn = $this->getState('list.direction', 'ASC');
@@ -589,17 +617,7 @@ class ImagesModel extends JoomListModel
     $query = $db->getQuery(true);
 
     // Initialize search service
-    $this->component->createConfig();
-    try
-    {
-      $searchProvider = $this->component->getSearch();
-    }
-    catch (\TypeError $e)
-    {
-      $searchProviderName = $this->component->getConfig()->get($this->search);
-      $this->component->createSearch($searchProviderName, $db, $this->state);
-      $searchProvider = $this->component->getSearch();
-    }
+    $searchProvider = $this->getSearchProvider();
 
     // Check if logic and is active
     $logicAnd = (bool) ($this->getState('filter.and') > 0);
@@ -657,6 +675,10 @@ class ImagesModel extends JoomListModel
       $query->from($db->quoteName('#__joomgallery', 'a'));
     }
 
+    // Join over the foreign key 'catid'.
+    $query->join('LEFT', $db->quoteName('#__joomgallery_categories', 'category'), $db->quoteName('category.id') . ' = ' . $db->quoteName('a.catid'));
+
+    // Join tags when the SQL search provider does not handle tag filtering.
     if(!$searchProvider->handlesFilter('tags') && !empty($tag) && !$logicAnd)
     {
       // Join with the tags and reference table to get tag IDs
@@ -702,26 +724,10 @@ class ImagesModel extends JoomListModel
     }
 
     // Filter by search
-    $search = $this->getState('filter.search');
+    $search = trim((string) $this->getState('filter.search'));
 
-    if(!empty($search))
-    {
-      if(stripos($search, 'id:') === 0)
-      {
-        $search = (int) substr($search, 3);
-        $query->where($db->quoteName('a.id') . ' = :search')
-          ->bind(':search', $search, ParameterType::INTEGER);
-      }
-      else
-      {
-        $search = '%' . str_replace(' ', '%', trim($search)) . '%';
-        $query->where(
-            '(' . $db->quoteName('a.title') . ' LIKE :search1 OR ' . $db->quoteName('a.alias') . ' LIKE :search2'
-            . ' OR ' . $db->quoteName('a.description') . ' LIKE :search3)'
-        )
-          ->bind([':search1', ':search2', ':search3'], $search);
-      }
-    }
+    // Let the provider decide whether the current search/filter state is active.
+    $searchProvider->applyToQuery($query, $search, 'a');
 
     // Filter by published state
     $published = (string) $this->getState('filter.published');
@@ -921,5 +927,80 @@ class ImagesModel extends JoomListModel
     }
 
     return $query;
+  }
+
+  /**
+   * Defines the name of the search provider to be used.
+   *
+   * @param   string  $name  Name of the search provider
+   *
+   * @return  void
+   *
+   * @since   4.4.0
+   */
+  public function setSearchProvider(string $name = 'sql')
+  {
+    if(str_starts_with($name, 'jg'))
+    {
+      // We expect the provider to be given by a configuration parameter
+      $this->search = $name;
+
+      return;
+    }
+
+    // Else we check the name of the available providers
+    $providers = $this->component->getSearchProviders();
+
+    foreach($providers as $provider)
+    {
+      if($provider['value'] == $name)
+      {
+        $this->search = $name;
+
+        return;
+      }
+    }
+
+    throw new \Exception('Requested search provider ("' . $name . '") does not exist.', 1);
+  }
+
+  /**
+   * Returns a serach provider service due to the provider name in the class
+   *
+   * @return  SearchInterface  Search provider service class
+   *
+   * @since   4.4.0
+   */
+  protected function getSearchProvider(): SearchInterface
+  {
+    try
+    {
+      $searchProvider = $this->component->getSearch();
+
+      if($searchProvider->getName() == $this->search)
+      {
+        // Correct search provider already created
+        return $searchProvider;
+      }
+    }
+    catch (\TypeError $e)
+    {
+      // No search provider initialized yet
+    }
+
+    // Guess the name of the serach provider
+    $searchProviderName = $this->search;
+
+    if(str_starts_with($this->search, 'jg'))
+    {
+      $this->component->createConfig();
+      $searchProviderName = $this->component->getConfig()->get($this->search, 'jg_backend_searchprovider');
+    }
+
+    // Create new serach provider service
+    $db = $this->getDatabase();
+    $this->component->createSearch($searchProviderName, $db, $this->state);
+
+    return $this->component->getSearch();
   }
 }

--- a/src/administrator/com_joomgallery/src/Service/Search/FinderSearch.php
+++ b/src/administrator/com_joomgallery/src/Service/Search/FinderSearch.php
@@ -46,6 +46,31 @@ class FinderSearch extends Search implements SearchInterface
   protected $filters = ['category', 'tags', 'language'];
 
   /**
+   * Return the SearchTools fields that are meaningful with Finder.
+   *
+   * @return  array<string, array|null>
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function getDisplayFields(): array
+  {
+    return [
+      'filter' => [
+        'search',
+        'published',
+        'category',
+        'tag',
+        'access',
+        'created_by',
+        'language',
+      ],
+      'list' => [
+        'limit',
+      ],
+    ];
+  }
+
+  /**
    * True if this search service applies ordering.
    *
    * @var   bool
@@ -61,6 +86,12 @@ class FinderSearch extends Search implements SearchInterface
    */
   protected array $boundValues = [];
 
+  /** @var bool Whether Finder ordering is available for the current query. */
+  protected bool $orderingAvailable = false;
+
+  /** @var string Direction of the current Finder ordering. */
+  protected string $orderingDirection = 'DESC';
+
   /**
    * Function to add the search to the query.
    *
@@ -74,6 +105,9 @@ class FinderSearch extends Search implements SearchInterface
    */
   public function applyToQuery(QueryInterface $query, string $term, string $alias = 'a'): void
   {
+    $this->orderingAvailable = false;
+    $this->orderingDirection = 'DESC';
+
     $term            = trim($term);
     $taxonomyNodeIds = $this->getFinderTaxonomyNodeIdsFromState();
 
@@ -170,6 +204,36 @@ class FinderSearch extends Search implements SearchInterface
         . ', ' . $this->db->quote('&id=') . ', -1), ' . $this->db->quote('&') . ', 1) AS UNSIGNED)'
         . ' = ' . $this->db->quoteName($alias . '.id')
     );
+
+    $this->orderingDirection = strtoupper((string) $finderModel->getState('list.direction', 'DESC'));
+
+    if(!\in_array($this->orderingDirection, ['ASC', 'DESC'], true))
+    {
+      $this->orderingDirection = 'DESC';
+    }
+
+    $this->orderingAvailable = true;
+  }
+
+  /**
+   * Apply Finder's calculated ordering to the final list query.
+   *
+   * @param   QueryInterface  $query  The final list query
+   *
+   * @return  bool  True when Finder ordering was applied.
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function applyOrderingToQuery(QueryInterface $query): bool
+  {
+    if(!$this->orderingAvailable)
+    {
+      return false;
+    }
+
+    $query->order($this->db->quoteName('fr.ordering') . ' ' . $this->orderingDirection);
+
+    return true;
   }
 
   /**

--- a/src/administrator/com_joomgallery/src/Service/Search/Search.php
+++ b/src/administrator/com_joomgallery/src/Service/Search/Search.php
@@ -16,6 +16,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Search;
 
 use Joomgallery\Component\Joomgallery\Administrator\Extension\ServiceTrait;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\SearchInterface;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Registry\Registry;
@@ -73,13 +74,13 @@ class Search implements SearchInterface
    * Constructor
    *
    * @param  DatabaseInterface  $db      The databse
-   * @param  Registry           $state   The state object
+   * @param  Registry|CMSObject $state   The state object
    *
    * @return  void
    *
    * @since   4.4.0
    */
-  public function __construct(DatabaseInterface $db, Registry $state)
+  public function __construct(DatabaseInterface $db, Registry|CMSObject $state)
   {
     $this->db    = $db;
     $this->state = $state;
@@ -107,6 +108,21 @@ class Search implements SearchInterface
   public function getFilters(): array
   {
     return $this->filters;
+  }
+
+  /**
+   * Return the filter-form fields that should be displayed for this provider.
+   *
+   * @return  array<string, array|null>
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function getDisplayFields(): array
+  {
+    return [
+      'filter' => null,
+      'list'   => null,
+    ];
   }
 
   /**
@@ -161,6 +177,20 @@ class Search implements SearchInterface
   public function handlesOrdering(): bool
   {
     return $this->ordering;
+  }
+
+  /**
+   * Apply provider-specific ordering to the final list query.
+   *
+   * @param   QueryInterface  $query  The final list query
+   *
+   * @return  bool  True when provider ordering was applied.
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function applyOrderingToQuery(QueryInterface $query): bool
+  {
+    return false;
   }
 
   /**

--- a/src/administrator/com_joomgallery/src/Service/Search/SearchInterface.php
+++ b/src/administrator/com_joomgallery/src/Service/Search/SearchInterface.php
@@ -43,6 +43,17 @@ interface SearchInterface
   public function getFilters(): array;
 
   /**
+   * Return the filter-form fields that should be displayed for this provider.
+   *
+   * A null fieldset value means that all its fields should be displayed.
+   *
+   * @return  array<string, array|null>
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function getDisplayFields(): array;
+
+  /**
    * Add the state to the service.
    *
    * @param   Registry  $state   The state object
@@ -83,6 +94,17 @@ interface SearchInterface
    * @since   4.4.0
    */
   public function handlesOrdering(): bool;
+
+  /**
+   * Apply provider-specific ordering to the final list query.
+   *
+   * @param   QueryInterface  $query  The final list query
+   *
+   * @return  bool  True when provider ordering was applied.
+   *
+   * @since   __DEPLOY_VERSION__
+   */
+  public function applyOrderingToQuery(QueryInterface $query): bool;
 
   /**
    * Method to get a list of possible options

--- a/src/administrator/com_joomgallery/src/Service/Search/SearchServiceTrait.php
+++ b/src/administrator/com_joomgallery/src/Service/Search/SearchServiceTrait.php
@@ -17,6 +17,7 @@ namespace Joomgallery\Component\Joomgallery\Administrator\Service\Search;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\FinderSearch;
 use Joomgallery\Component\Joomgallery\Administrator\Service\Search\SQLSearch;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
@@ -68,14 +69,14 @@ trait SearchServiceTrait
   /**
    * Creates the search helper class
    *
-   * @param   string      $search  Name of the search to be used
-   * @param   Registry    $state   The state object
+   * @param   string               $search  Name of the search to be used
+   * @param   Registry|CMSObject   $state   The state object
    *
    * @return  void
    *
    * @since  4.4.0
    */
-  public function createSearch($search, DatabaseInterface $db, Registry $state): void
+  public function createSearch($search, DatabaseInterface $db, Registry|CMSObject $state): void
   {
     switch($search)
     {

--- a/src/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/src/site/com_joomgallery/src/Model/CategoryModel.php
@@ -58,6 +58,7 @@ class CategoryModel extends JoomItemModel
     if($this->imagesModel === null)
     {
       $this->imagesModel = $this->component->getMVCFactory()->createModel('images', 'site', ['context' => 'com_joomgallery.category.images']);
+      $this->imagesModel->setSearchProvider('sql');
       $this->imagesModel->getState();
     }
 

--- a/src/site/com_joomgallery/src/Model/GalleryModel.php
+++ b/src/site/com_joomgallery/src/Model/GalleryModel.php
@@ -55,8 +55,8 @@ class GalleryModel extends JoomItemModel
   {
     parent::__construct($config);
 
-    $this->imagesModel         = $this->component->getMVCFactory()->createModel('images', 'site', ['context' => 'com_joomgallery.gallery.images']);
-    $this->imagesModel->search = 'jg_gallery_view_searchprovider';
+    $this->imagesModel = $this->component->getMVCFactory()->createModel('images', 'site', ['context' => 'com_joomgallery.gallery.images']);
+    $this->imagesModel->setSearchProvider('jg_gallery_view_searchprovider');
     $this->imagesModel->getState();
   }
 


### PR DESCRIPTION
This PR improves the way search providers handles the ordering of the results in images list views like the `images view` in the backend or the `gallery view` in the frontend.

When the Finder search provider is selected, image search results are now reliably sorted by Finder relevance. The filter toolbar also adapts to the selected provider: options that do not apply to Finder, such as manual sorting and the tag AND/OR selector, are hidden. With the standard SQL provider, all regular filtering and sorting options remain available. These changes apply to both frontend and backend image lists.

### How to test this PR
Change the search provider settings in frontend and backend and check the functionality. Does the search providers behave as you expect it?