### PR TITLE
[Bugfix] Bildertitel bei Lightbox-Galerie

### DIFF
--- a/src/site/com_joomgallery/layouts/joomgallery/grids/images.php
+++ b/src/site/com_joomgallery/layouts/joomgallery/grids/images.php
@@ -97,7 +97,7 @@ extract($displayData);
             </div>
           <?php endif; ?>
 
-          <?php if($layout == 'justified') : ?>
+          <?php if($image_title && $layout == 'justified') : ?>
             <div class="jg-image-caption-hover <?php echo $this->escape($caption_align); ?>">
               <?php echo $this->escape($item->title); ?>
             </div>


### PR DESCRIPTION
I was made aware that in the JoomPlu PRO Plugin the image title is showed in the justified layout even though it was configured not to be shown. It appears to be a bug in JoomGallery not in the Plugin.

See: https://www.forum.joomgalleryfriends.net/forum/index.php?thread/508-joomplu-plugin-pro-und-einige-probleme/&postID=3055#post3055

This PR fixes this issue.