### PR TITLE
[Bugfix] Load params to CategoryModel state

### DIFF
--- a/src/site/com_joomgallery/src/Model/CategoryModel.php
+++ b/src/site/com_joomgallery/src/Model/CategoryModel.php
@@ -90,11 +90,11 @@ class CategoryModel extends JoomItemModel
 
     if($id)
     {
-      $this->app->setUserState('com_joomgallery.edit.image.id', $id);
+      $this->app->setUserState('com_joomgallery.edit.category.id', $id);
     }
     else
     {
-      $id = (int) $this->app->getUserState('com_joomgallery.edit.image.id', null);
+      $id = (int) $this->app->getUserState('com_joomgallery.edit.category.id', null);
     }
 
     if(\is_null($id))
@@ -103,6 +103,24 @@ class CategoryModel extends JoomItemModel
     }
 
     $this->setState('category.id', $id);
+
+    $this->loadComponentParams($id);
+  }
+
+  /**
+   * Method to load component specific parameters into model state.
+   *
+   * @param   int   $id   ID of the content if needed (default: 0)
+   *
+   * @return  void
+   * @since   4.4.1
+   */
+  public function addComponentParams($id = 0)
+  {
+    if($id < 1)
+    {
+      $id = $this->app->input->getInt('id', null);
+    }
 
     $this->loadComponentParams($id);
   }


### PR DESCRIPTION
Before this PR it was not possible to load JoomGallery component params into the category model state when the model was initiated using
```
$component->getMVCFactory()->createModel('category', 'site', ['ignore_request' => true]);
```
sometimes it is especially required to initiate this model while ignoring request variables but still want to use the JoomGallery component params. For this specific use case, this PR introduces a public method `addComponentParams()` doing that.

This PR is not expecting to break any existing code as it just adds a method which is currently not used anywhere in JoomGallery component, but is very much needed to develop custom extensions.