### PR TITLE
Remove finder database entries when uninstalling

### DIFF
--- a/src/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/src/administrator/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -22,3 +22,5 @@ DELETE `#__fields_values` FROM `#__fields_values` INNER JOIN `#__fields` ON `#__
 DELETE FROM `#__fields_groups` WHERE (context LIKE 'com_joomgallery%');
 DELETE FROM `#__fields` WHERE (context LIKE 'com_joomgallery%');
 DELETE FROM `#__scheduler_tasks` WHERE (type LIKE 'joomgallery%');
+DELETE `#__finder_links` FROM `#__finder_links` INNER JOIN `#__finder_types` ON `#__finder_types`.`id` = `#__finder_links`.`type_id` WHERE (`#__finder_types`.`title` LIKE 'Image (JoomGallery)');
+DELETE `#__finder_types` FROM `#__finder_types` WHERE (`#__finder_types`.`title` LIKE 'Image (JoomGallery)');


### PR DESCRIPTION
Currently, when the component is uninstalled, the JoomGallery entries remain in the Joomla! finder tables.
This pull request removes the entries from the 'finder' tables when uninstallation.